### PR TITLE
fix(ci): correct actions/deploy-pages SHA pin for v4

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,4 +46,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac553fd0d31 # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

The docs deploy workflow fails because `actions/deploy-pages` is pinned to a SHA that no longer exists in the upstream repo.

**Before:** `d6db90164ac5ed86f2b6aed7e0febac553fd0d31` (not found)
**After:** `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5)

Fixes deploy workflow run #8.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] No edits inside managed blocks of hatch3r-* files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a pinned GitHub Action SHA in the docs deploy workflow, with no application/runtime code changes.
> 
> **Overview**
> Fixes the docs GitHub Pages deployment workflow by updating the pinned `actions/deploy-pages` v4 SHA in `.github/workflows/deploy-docs.yml` to a valid upstream commit so deploy runs no longer fail.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35e8a3734504599d649b675a647441bf030d8bee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->