### PR TITLE
feat(cli): streamline config content flow, default to full preset and claude tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ docs-site/.docusaurus/
 
 # Audit scratch files
 governance/AUDIT-REPORT.md
+governance/EVOLVE-REPORT.md
 .audit-workspace/
 .agents/
 skills-lock.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [1.5.1] - 2026-04-14
+
+### Changed
+
+- **Config content flow**: Replaced "Manage content items?" confirm prompt with direct preset selection (minimal/standard/full/custom) and tag-grouped custom picker, matching the init experience
+- **Default content profile**: Changed default from "Standard" to "Full (recommended)" for both interactive and headless (`--yes`) init
+- **Default tool fallback**: Changed fallback tool from Cursor to Claude Code when auto-detection finds no existing tools
+
 ## [1.5.0] - 2026-04-13
 
 ### Added

--- a/commands/hatch3r-revision.md
+++ b/commands/hatch3r-revision.md
@@ -1,7 +1,7 @@
 ---
 id: hatch3r-revision
 type: command
-description: User-guided revision of agent-implemented code in a fresh context window. Reconstructs what was done, interviews the user for feedback, fixes issues, cleans up leftovers, and drives toward merge readiness.
+description: User-guided revision of agent-implemented code in a fresh context window. Reconstructs what was done, interviews the user for feedback, fixes issues, cleans up leftovers, and drives toward merge readiness. Delegation, quality pipeline, modes, and board integration details are in commands/revision/.
 tags: [implementation, team]
 quality_charter: agents/shared/quality-charter.md
 ---
@@ -15,7 +15,10 @@ quality_charter: agents/shared/quality-charter.md
 | 3. Leftover Scan + Triage Routing | Orchestrator (inline) | No | Yes |
 | 4. Fix Implementation | `hatch3r-implementer`, `hatch3r-lint-fixer`, `hatch3r-test-writer` | Per finding type | [FIX NOW] items only |
 | 5a. Review Loop | `hatch3r-reviewer` -> `hatch3r-fixer` (max 3 iterations) | No (sequential) | Yes |
-| 5b. Final Quality | `hatch3r-test-writer` + `hatch3r-security-auditor` | Yes | Yes (code changes) |
+| 5b. Final Quality — Testing | `hatch3r-test-writer` | Yes | Yes (code changes) |
+| 5c. Final Quality — Security | `hatch3r-security-auditor` | Yes | Yes (code changes) |
+| 5d. Final Quality — Docs | `hatch3r-docs-writer` | Yes | When APIs/architecture/UX affected |
+| 5e. Final Quality — Conditional | `hatch3r-lint-fixer`, `hatch3r-a11y-auditor`, `hatch3r-perf-profiler` | Yes | When triggered |
 
 ## Browser Automation
 
@@ -37,7 +40,7 @@ The user is the reviewer. The agent is the interviewer and fixer.
 
 ## Shared Context
 
-**If board context exists** (current branch has an associated PR linked to GitHub issues), **read the `hatch3r-board-shared` command at the start of the run.** It contains Board Configuration, GitHub Context, Project Reference, and tooling directives. Cache all values for the duration of this run.
+**If board context exists** (current branch has an associated PR linked to issues), **read the `hatch3r-board-shared` command at the start of the run.** It contains Board Configuration, Platform Detection, Platform Context, Board Sync Procedure, and tooling directives. Cache all values for the duration of this run.
 
 If no board context exists (plain instruction, no PR, no linked issues), skip shared context loading and work from the git diff alone.
 
@@ -51,6 +54,10 @@ If no board context exists (plain instruction, no PR, no linked issues), skip sh
 2. **Targeted file reads only.** When scanning for leftovers in Step 4, read only the files that appear in the diff -- not the full codebase.
 3. **Do NOT re-read shared context files** -- their content is available via always-applied rules or inline in this command.
 4. **Limit documentation reads.** Read project documentation selectively -- TOC/headers first, full content only for relevant sections.
+
+## Run Cache
+
+Initialize the run cache at the start of the workflow. See `commands/revision/revision-board-integration.md` for the full schema. The cache tracks: diff, findings with triage routing and fix status, quality agents spawned, errors encountered.
 
 ---
 
@@ -68,16 +75,22 @@ Rebuild full context in the fresh window. No prior implementation context is ass
 2. Determine the default branch from `.agents/hatch.json` (`board.defaultBranch`). Fall back to `main` if unavailable.
 3. Compute the diff: `git diff {defaultBranch}...HEAD --stat` for a summary, then `git diff {defaultBranch}...HEAD` for the full diff.
 4. Parse the diff summary: files changed, lines added/removed, file types affected.
-5. Identify affected areas from the file paths (e.g., `src/routes/` → API, `src/components/` → UI, `tests/` → testing).
+5. Identify affected areas from the file paths (e.g., `src/routes/` -> API, `src/components/` -> UI, `tests/` -> testing).
 
 #### 1b. Find Associated PR and Issues
 
-1. Search for an open PR on this branch: `gh pr list --head {branch} --state open --json number,title,body,url --limit 1`.
-2. If a PR exists:
+> Platform-specific CLI commands: see `commands/board/shared-{platform}.md` for PR/issue lookup
+
+1. Detect the platform from `.agents/hatch.json` (`board.platform`). Fall back to GitHub if unavailable.
+2. Search for an open PR on this branch using the platform CLI:
+   - **GitHub:** `gh pr list --head {branch} --state open --json number,title,body,url --limit 1`
+   - **Azure DevOps:** `az repos pr list --source-branch {branch} --status active --top 1`
+   - **GitLab:** `glab mr list --source-branch {branch} --state opened --per-page 1`
+3. If a PR exists:
    - Read the PR body.
    - Extract linked issues from `Closes #N`, `Fixes #N`, `Relates to #N` references.
-   - For each linked issue: `gh issue view {N} --json title,body,labels` to read acceptance criteria and labels.
-3. If no PR exists: note this and work from the branch diff alone.
+   - For each linked issue: fetch title, body, labels, and acceptance criteria using the platform CLI.
+4. If no PR exists: note this and work from the branch diff alone.
 
 #### 1c. Load Project Rules
 
@@ -96,6 +109,7 @@ Present a reconstruction summary to the user:
 ```
 Revision Context:
   Branch: {branch}
+  Platform: {GitHub / Azure DevOps / GitLab}
   PR: #{N} — {title} ({url}) | No PR found
   Linked issues: #{N} — {title} (×{count}) | None
   Diff: {files_changed} files changed (+{additions} / -{deletions})
@@ -265,7 +279,7 @@ If the user attempts to defer a Critical finding, execute the Critical Deferral 
      Deferral rationale: {user's stated rationale}
    ```
 
-4. **Flag for triage.** The `Critical-deferred` tag ensures board-fill surfaces this item with elevated visibility during the next triage cycle. Board-fill should treat `Critical-deferred` items as priority:p0 candidates regardless of other signals.
+4. **Flag for triage.** The `Critical-deferred` tag signals board-fill to surface this item with elevated visibility during the next triage cycle. Board-fill should treat `Critical-deferred` items as priority:p0 candidates regardless of other signals.
 
 The user is never blocked — this protocol adds accountability, not a veto.
 
@@ -299,7 +313,7 @@ If any findings are routed to [DEFER]:
 2. Present summary:
    `"Deferred {N} findings to todo.md. Run /hatch3r-board-fill to triage them into an epic with full dependency analysis."`
 
-3. Cache the deferred findings list for use in Steps 8 and 9.
+3. Cache the deferred findings list for use in Steps 8 and 9. Update run cache `deferred_findings`.
 
 If no findings are routed to [DEFER] (including the "fix all" shortcut), skip this sub-step entirely.
 
@@ -307,99 +321,19 @@ If no findings are routed to [DEFER] (including the "fix all" shortcut), skip th
 
 ### Step 6: Fix Implementation (Sub-Agent Delegation)
 
-Delegate [FIX NOW] findings to specialist sub-agents via the Task tool. Group findings by specialist and parallelize where possible. [DEFER] findings have been appended to `todo.md` in Step 5c and are excluded from this step.
+> Full details: see `commands/revision/revision-delegation.md`
+
+Delegate [FIX NOW] findings to specialist sub-agents. The delegation protocol covers complexity assessment (using `hatch3r-deep-context` scoring), blast-radius-aware finding grouping, expanded sub-agent prompt templates, and cross-agent conflict resolution.
 
 If all findings were deferred (no [FIX NOW] items), skip Step 6 entirely and proceed to Step 7.
-
-#### 6a. Group Findings by Specialist
-
-| Finding Category | Sub-Agent | Protocol |
-|-----------------|-----------|----------|
-| Bugs, missing features, error handling, logic fixes | `hatch3r-implementer` | hatch3r-implementer agent protocol |
-| Dead code, unused imports, type fixes, lint errors | `hatch3r-lint-fixer` | hatch3r-lint-fixer agent protocol |
-| Missing tests, insufficient coverage | `hatch3r-test-writer` | hatch3r-test-writer agent protocol |
-
-If findings span multiple independent areas, spawn one `hatch3r-implementer` per area to parallelize.
-
-#### 6b. Spawn Sub-Agents
-
-Use the Task tool with `subagent_type: "generalPurpose"`. Launch as many independent sub-agents in parallel as the platform supports.
-
-Each sub-agent prompt MUST include:
-- The specific findings to address (file paths, line numbers, descriptions, expected behavior).
-- Instruction to follow the corresponding agent protocol (e.g., "Follow the hatch3r-implementer agent protocol").
-- All `scope: always` rule directives from `.agents/rules/` -- sub-agents do not inherit rules automatically.
-- Acceptance criteria from linked issues (if available from Step 1b).
-- Relevant learnings from `.agents/learnings/` (if found in Step 1d).
-- Explicit instruction: do NOT create branches, commits, or PRs.
-- Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
-
-#### 6c. Await and Integrate Results
-
-1. Await all sub-agents. Collect their structured results (files changed, tests written, issues encountered).
-2. If any sub-agent reports BLOCKED or PARTIAL, **ASK** the user how to proceed (skip, provide guidance, fix manually).
-3. If sub-agents modified overlapping files, review for conflicts and resolve.
-4. Apply all changes to the working tree.
 
 ---
 
 ### Step 7: Quality Verification
 
-Run the project's quality checks. Refer to `package.json` scripts, `README.md`, or `AGENTS.md` for the appropriate commands.
+> Full details: see `commands/revision/revision-quality.md`
 
-#### 7a. Run Quality Gates
-
-1. Lint check (e.g., `npm run lint`)
-2. Type check (e.g., `npm run typecheck`)
-3. Test suite (e.g., `npm run test`)
-
-#### 7b. Verify User-Reported Issues
-
-Walk through each critical and important finding from Step 5. Verify it is addressed by the changes made in Step 6. If acceptance criteria exist from linked issues, verify each criterion.
-
-For each verified finding and acceptance criterion, rate verification confidence: high (fix confirmed via tests or direct observation), medium (code change addresses the issue but edge cases not independently tested), low (fix applied but uncertain of completeness).
-
-#### 7c. Review Loop
-
-Run an iterative review loop (max 3 iterations) until 0 Critical + 0 Warning findings remain:
-
-1. Spawn `hatch3r-reviewer` sub-agent via the Task tool (`subagent_type: "generalPurpose"`).
-
-The reviewer prompt MUST include:
-- The diff of all changes made (use `git diff` on the working tree).
-- All `scope: always` rule directives from `.agents/rules/`.
-- Iteration number and previous findings (if not the first iteration).
-- Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
-
-2. Process reviewer output:
-   - If **0 Critical and 0 Warning** findings: review loop is clean. Proceed to Step 7d.
-   - If Critical or Warning findings remain: spawn `hatch3r-fixer` sub-agent to address them, then re-run the reviewer (next iteration).
-
-3. If 3 iterations complete and findings remain, **ASK** the user whether to proceed or fix manually.
-
-After each reviewer iteration, assess the reviewer's findings confidence: if the reviewer rates any finding as low-confidence, flag it separately in the ASK prompt so the user can prioritize human review of uncertain findings.
-
-4. After any fixes, re-run quality gates (Step 7a) to verify nothing broke.
-
-#### 7d. Final Quality
-
-After the review loop is clean, spawn both agents in parallel via the Task tool:
-
-1. `hatch3r-test-writer` — write or update tests for code changes.
-2. `hatch3r-security-auditor` — security review of code changes.
-
-Both prompts MUST include:
-- The diff of all changes made.
-- All `scope: always` rule directives from `.agents/rules/`.
-- Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
-
-Apply any resulting changes (new tests, security fixes). Re-run quality gates (Step 7a) if changes were made.
-
-#### 7e. Handle Failures
-
-- If quality checks fail: identify the specific failures, fix them directly (for simple issues) or loop back to Step 6 with specific failures.
-- Max 2 retry loops on quality check failures. After 2 retries, **ASK** the user for guidance: "Quality checks still failing. Fix confidence: {high/medium/low — based on whether root cause is identified}."
-- If a user-reported issue was not fully addressed: **ASK** the user whether to attempt another fix or defer.
+Two-stage quality pipeline: Stage 1 runs a sequential review loop (`hatch3r-reviewer` -> `hatch3r-fixer`, max 3 iterations). Stage 2 spawns final quality specialists in parallel — mandatory (`hatch3r-test-writer`, `hatch3r-security-auditor`), evaluated (`hatch3r-docs-writer`), and conditional (`hatch3r-a11y-auditor`, `hatch3r-perf-profiler`, `hatch3r-lint-fixer`).
 
 ---
 
@@ -429,6 +363,8 @@ git push
   ```
 
 If `git push` fails (e.g., remote branch does not exist yet), use `git push -u origin {branch}`.
+
+**Post-commit board integration:** If board context exists, update the PR description with a revision summary. See `commands/revision/revision-board-integration.md` for the full procedure.
 
 ---
 
@@ -460,7 +396,17 @@ Verdict: READY / NOT READY ({remaining items})
 
 A deferred finding counts as "tracked" not "unaddressed" -- it does not block merge readiness.
 
-#### 9b. Present Assessment
+#### 9b. Board Housekeeping
+
+> Full details: see `commands/revision/revision-board-integration.md`
+
+When board context exists, run the board housekeeping steps:
+- **9b.i. Refresh Board Dashboard** (mandatory when `meta:board-overview` exists).
+- **9b.ii. Lightweight Reconciliation** — verify PR body integrity, deferred findings in todo.md, and issue status consistency.
+
+When no board context exists, skip 9b entirely.
+
+#### 9c. Present Assessment
 
 **ASK:** "Revision complete. {verdict}. Options: (a) ready to merge, (b) run another revision cycle with new feedback, (c) done for now."
 
@@ -490,27 +436,8 @@ Capture revision-specific learnings. Focus on patterns that inform future implem
 
 ---
 
-## Error Handling
+## Auto-Advance Mode, Error Handling, and Guardrails
 
-- **Git diff failure**: If `git diff` fails (e.g., no commits on branch, detached HEAD), **ASK** the user for the correct branch or base ref.
-- **No changes detected**: If the diff is empty, inform the user and exit. There is nothing to revise.
-- **PR/issue fetch failure**: Proceed without PR/issue context. Work from the diff alone. Warn the user that acceptance criteria are unavailable.
-- **Sub-agent failure**: Retry once. If the retry fails, fall back to direct implementation for that finding.
-- **Quality check failure after 2 retries**: Present the specific failures and **ASK** the user whether to proceed with a partial fix commit or continue debugging.
-- **Push failure**: Present the error. Common fixes: `git push -u origin {branch}` for new branches, `git pull --rebase` for diverged branches.
-- **Context degradation (>25 turns)**: Suggest starting a fresh chat with a progress summary. The revision command is designed for fresh contexts -- it can be re-run.
+> Full details: see `commands/revision/revision-modes.md`
 
-## Guardrails
-
-- **Never skip ASK checkpoints.** Every significant decision requires user confirmation.
-- **Never skip the proactive scan (Step 4)** -- even if the user reports no issues. Agents leave leftovers.
-- **Always run quality checks (Step 7)** before committing. Never commit code that fails lint, typecheck, or tests.
-- **Stay within the revision scope.** Fix what was reported and what the scan found. Do not refactor unrelated code, add new features, or expand beyond the original implementation's intent.
-- **Always commit and push** at the end of a revision cycle. The user invoked this command to get fixes merged -- do not exit without committing (unless the user explicitly abandons).
-- **Respect the original implementation's architecture.** Revision fixes issues within the existing patterns. If the architecture itself is flawed, note it as a finding but do not restructure -- suggest a separate refactor instead.
-- **One sub-agent per concern.** Delegate to specialist sub-agents based on finding type. Do not ask the implementer to also fix lint issues or write tests.
-- **Git safety.** Never force-push. Never rewrite history. Always create new commits for revision changes.
-- **This command composes existing hatch3r agents** -- it does not replace them. The reviewer, implementer, lint-fixer, and test-writer agents handle the actual work.
-- **Critical findings default to FIX NOW.** If the user overrides this, execute the Critical Deferral Protocol (Step 5b): structured warning with specific risk, require written rationale, record in todo.md with `Critical-deferred` tag, and flag for elevated triage in board-fill. The user is never blocked — rationale adds accountability, not a veto.
-- **Deferred findings go to `todo.md`, not directly to GitHub issues.** The board-fill pipeline handles triage, epic creation, dependency analysis, and readiness assessment. Revision does not shortcut this process.
-- **Always format deferred items as a single epic block** in `todo.md`, regardless of count. This ensures board-fill groups them together during the next run.
+The modes file contains: auto-advance mode (`--auto`), safety guardrails, error handling, and session report format for revision.

--- a/commands/revision/revision-board-integration.md
+++ b/commands/revision/revision-board-integration.md
@@ -1,0 +1,87 @@
+---
+id: hatch3r-revision-board-integration
+type: command
+description: Board integration for revision. Covers run cache schema, post-commit PR updates, dashboard refresh (Step 9a), and lightweight reconciliation (Step 9b).
+tags: [implementation, team]
+quality_charter: agents/shared/quality-charter.md
+---
+# Revision — Board Integration
+
+Board integration protocols for `hatch3r-revision`. Referenced from the core command file. All board integration steps are conditional — they execute only when board context exists (PR with linked issues found in Step 1b). When no board context exists, skip all steps in this file silently.
+
+---
+
+## Run Cache
+
+Initialize at the start of the revision workflow (before Step 1). Maintain throughout the run:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `diff_cache` | `string` | Cached diff from Step 1 (reused per token-saving directives) |
+| `findings` | `Map<id, {description, severity, route, status}>` | All findings with triage routing and fix status |
+| `fixed_findings` | `id[]` | Finding IDs resolved in this run |
+| `deferred_findings` | `id[]` | Finding IDs written to todo.md |
+| `quality_agents` | `{agent, status, findings_count}[]` | Specialist agents spawned and their results |
+| `pr_updated` | `boolean` | Whether PR description was updated with revision summary |
+| `errors` | `{step, message, recoverable}[]` | All errors encountered during the run |
+
+---
+
+## Post-Commit Board Integration (After Step 8)
+
+After committing and pushing revision changes, update the PR if board context exists:
+
+1. **Update PR description** with a revision summary appended to the existing body:
+
+   ```markdown
+   ---
+   ## Revision Summary ({date})
+   
+   **Fixed ({N}):**
+   - {finding description} ({severity})
+   - ...
+   
+   **Deferred to todo.md ({M}):**
+   - {finding description} ({severity})
+   - ...
+   
+   **Quality agents:** {list of agents spawned}
+   **Overall confidence:** {high/medium/low}
+   ```
+
+2. Do NOT change issue status labels. Revision does not alter the issue lifecycle — the original PR's `Closes #N` references handle that on merge.
+
+3. Do NOT modify `Closes #N` / `Relates to #N` references in the PR body. The original references from board-pickup are authoritative.
+
+---
+
+## Step 9a: Refresh Board Dashboard
+
+**This step is mandatory when board context exists. Skip silently when no board context.**
+
+If a `meta:board-overview` issue exists on the board, refresh it now using cached board data. Use the same procedure as `hatch3r-board-pickup` Step 9a: update with current board state reflecting any changes from this revision session.
+
+Do NOT re-fetch all issues. Use cached data from Step 1 combined with mutations from this run (findings fixed, PR updated). Skip silently if no `meta:board-overview` issue exists.
+
+---
+
+## Step 9b: Lightweight Reconciliation
+
+**This step is mandatory when board context exists. Skip silently when no board context.**
+
+Run a focused reconciliation (not the full board-shared reconciliation procedure, since revision does not create or update issues):
+
+1. **PR body integrity:** Verify the PR body still contains correct `Closes #N` references for all linked issues after the revision summary was appended. If any references were accidentally removed or corrupted, restore them.
+
+2. **Deferred findings integrity:** If findings were deferred in Step 5c, verify they are written to `todo.md` with correct severity tags and epic grouping format. Report any write failures.
+
+3. **Orphaned status check:** For each issue linked to this PR, verify the issue still has `status:in-review` label. If any issue has drifted to a different status (e.g., manually changed during the revision session), warn the user.
+
+Output a reconciliation report:
+
+```
+Reconciliation:
+  PR body: {ok / {N} references restored}
+  Deferred findings: {ok / {N} write failures}
+  Issue status: {ok / {N} status drift warnings}
+```

--- a/commands/revision/revision-delegation.md
+++ b/commands/revision/revision-delegation.md
@@ -1,0 +1,93 @@
+---
+id: hatch3r-revision-delegation
+type: command
+description: Fix delegation protocol for revision Step 6. Covers complexity-aware grouping, blast radius context, sub-agent prompt templates, and cross-agent conflict resolution.
+tags: [implementation, team]
+quality_charter: agents/shared/quality-charter.md
+---
+# Revision — Fix Delegation (Step 6)
+
+Delegation details for Step 6 of `hatch3r-revision`. Referenced from the core command file.
+
+---
+
+## 6.pre: Complexity Assessment
+
+Before delegating [FIX NOW] findings, score the aggregate fix batch using `hatch3r-deep-context` complexity signals. Score across the full set of findings, not per-finding:
+
+| Signal | Weight | Detection |
+|--------|--------|-----------|
+| Findings span multiple modules/layers | +3 | Count distinct directories across all [FIX NOW] findings |
+| Any finding involves behavioral contract changes (API, types, events) | +2 | Check finding descriptions for interface/signature changes |
+| Findings touch security-sensitive areas (auth, payments, data access) | +2 | Match affected files against security-sensitive directories |
+| Total affected files > 5 | +2 | Count distinct files across all findings |
+| Any finding requires new dependencies or integrations | +2 | Check whether fixes introduce new imports or services |
+
+### Tier Assignment
+
+| Total Weight | Tier | Action |
+|-------------|------|--------|
+| 0–2 | 1 (Light) | Proceed directly to 6a. No research needed |
+| 3–5 | 2 (Standard) | Spawn `hatch3r-researcher` with `similar-implementation` at `quick` depth before delegating. Use discovered reference patterns to inform fix conventions |
+| 6+ | 3 (Deep) | Spawn `hatch3r-researcher` with `codebase-impact` at `deep` depth. **Warn the user** that fix scope may warrant a new board issue rather than a revision fix |
+
+For Tier 2/3: cache researcher output (reference conventions, blast radius data) for inclusion in sub-agent prompts below.
+
+---
+
+## 6a. Group Findings by Specialist
+
+| Finding Category | Sub-Agent | Protocol |
+|-----------------|-----------|----------|
+| Bugs, missing features, error handling, logic fixes | `hatch3r-implementer` | hatch3r-implementer agent protocol |
+| Dead code, unused imports, type fixes, lint errors | `hatch3r-lint-fixer` | hatch3r-lint-fixer agent protocol |
+| Missing tests, insufficient coverage | `hatch3r-test-writer` | hatch3r-test-writer agent protocol |
+
+### Blast-Radius-Aware Grouping
+
+When multiple findings affect the same file or module, batch them to a single sub-agent to avoid cross-agent file conflicts:
+
+1. Build a file-to-findings map from all [FIX NOW] items.
+2. Findings in the same file go to the same sub-agent instance, even if they span categories (use the highest-priority specialist: implementer > lint-fixer > test-writer).
+3. Findings in disjoint files can run in parallel sub-agents.
+4. If findings span independent areas within the same specialist type, spawn one sub-agent per area to parallelize.
+
+---
+
+## 6b. Spawn Sub-Agents
+
+Use the Task tool with `subagent_type: "generalPurpose"`. Launch independent sub-agents in parallel.
+
+Each sub-agent prompt MUST include:
+
+1. The specific findings to address (file paths, line numbers, descriptions, expected behavior).
+2. Instruction to follow the corresponding agent protocol (e.g., "Follow the hatch3r-implementer agent protocol").
+3. All `scope: always` rule directives from `.agents/rules/` — sub-agents do not inherit rules automatically.
+4. Acceptance criteria from linked issues (if available from Step 1b).
+5. Relevant learnings from `.agents/learnings/` (if found in Step 1d).
+6. Explicit instruction: do NOT create branches, commits, or PRs.
+7. Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
+8. Revision-specific constraint: "You are fixing existing code, not implementing new features. Stay within the architecture established by the original implementation."
+
+**When Tier 2/3 research was performed (6.pre):**
+
+9. Reference conventions from `similar-implementation` output — triggers the implementer's Convention Lock step.
+10. Blast radius data from `codebase-impact` output (Tier 3) — transitive dependency trace informing which consumers and contracts the fix must preserve.
+
+---
+
+## 6c. Await and Integrate Results
+
+1. Await all sub-agents. Collect their structured results (files changed, tests written, issues encountered).
+2. If any sub-agent reports BLOCKED or PARTIAL, **ASK** the user how to proceed (skip, provide guidance, fix manually).
+
+### Cross-Agent Conflict Resolution
+
+When sub-agents modified overlapping files:
+
+- **Disjoint regions** (different functions, different sections): accept both sets of changes.
+- **Overlapping regions** (same function or block): merge using the larger-scope change as the base, applying the smaller change on top. If merging is ambiguous, present both versions to the user.
+- **Semantic conflicts** (contradictory logic): surface to the user with both sub-agents' rationale. Do not auto-resolve semantic conflicts.
+
+3. Apply all resolved changes to the working tree.
+4. Update the run cache with fix results (files changed, findings addressed).

--- a/commands/revision/revision-modes.md
+++ b/commands/revision/revision-modes.md
@@ -1,0 +1,91 @@
+---
+id: hatch3r-revision-modes
+type: command
+description: Auto-advance mode, safety guardrails, error handling, and session report for revision. Covers --auto operation, never-skip rules, platform-aware error recovery, and end-of-session summary.
+tags: [implementation, team]
+quality_charter: agents/shared/quality-charter.md
+---
+# Revision — Modes, Guardrails, and Error Handling
+
+Supplementary protocols for `hatch3r-revision`. Referenced from the core command file.
+
+---
+
+## Auto-Advance Mode
+
+When invoked with `--auto`, revision operates with reduced human checkpoints for sustained autonomous operation (e.g., CI integration, repeated revision cycles).
+
+### Behavior Changes in Auto Mode
+
+| Checkpoint | Normal Mode | Auto Mode |
+|-----------|-------------|-----------|
+| Step 2 context validation | ASK user | Auto-proceed when PR + linked issues found. If no PR found, fall back to normal mode for this step |
+| Step 3 user interview | ASK user for feedback | Skip interview. Work from leftover scan (Step 4) only |
+| Step 5b routing approval | ASK user to confirm routing | Auto-accept suggested routing heuristics |
+| Step 7e quality failure | ASK user after 2 retries | Auto-defer remaining findings to todo.md after 2 retries |
+| Step 9b merge readiness | ASK user for next action | Auto-select (a) ready to merge when READY; auto-select (c) done for now when NOT READY |
+
+### Safety Guardrails (Never Skipped)
+
+These checkpoints are NEVER skipped, even in auto mode:
+
+- **Critical findings** default to FIX NOW. If a critical finding cannot be fixed after 2 retries, auto-mode records it as `Critical-deferred` with rationale "auto-deferred: fix attempts exhausted after 2 retries" and the `Critical-deferred` tag in todo.md
+- **Quality gates** (lint, typecheck, tests) must pass before commit. Auto-mode does not bypass quality checks
+- **Critical Deferral Protocol** still applies — auto-mode provides a structured rationale rather than skipping the protocol
+- **No force-push.** Never rewrite history
+- **Max 2 retry loops** on quality failures. Auto-mode does not retry indefinitely
+- **Proactive leftover scan** (Step 4) always runs. This is the primary input in auto-mode since the user interview is skipped
+
+### Activation
+
+```
+/hatch3r revision --auto
+```
+
+### Session Report
+
+At the end of an auto session (or any session when `--auto` is active), generate a summary:
+
+```
+Revision Session Report:
+  Findings: {N} total ({critical}/{important}/{cleanup}/{cosmetic})
+  Fixed: {N}
+  Deferred: {M} (written to todo.md)
+  Quality agents spawned: {list}
+  Quality gate status: {pass/fail}
+  Commits: {N}
+  Learnings captured: {count}
+  Overall confidence: {high/medium/low}
+```
+
+---
+
+## Error Handling
+
+> Platform-specific CLI commands: see `commands/board/shared-{platform}.md` for fallback chains
+
+- **Git diff failure**: If `git diff` fails (e.g., no commits on branch, detached HEAD), **ASK** the user for the correct branch or base ref.
+- **No changes detected**: If the diff is empty, inform the user and exit. There is nothing to revise.
+- **PR/issue fetch failure**: Retry once using the platform CLI. If retry fails, proceed without PR/issue context. Work from the diff alone. Warn the user that acceptance criteria are unavailable.
+- **Sub-agent failure**: Retry once. If the retry fails, fall back to direct implementation for that finding.
+- **Quality check failure after 2 retries**: Present the specific failures and **ASK** the user whether to proceed with a partial fix commit or continue debugging.
+- **Push failure**: Present the error. Common fixes: `git push -u origin {branch}` for new branches, `git pull --rebase` for diverged branches.
+- **Context degradation (>25 turns)**: Suggest starting a fresh chat with a progress summary. The revision command is designed for fresh contexts — it can be re-run.
+- **Board sync failure** (when board context exists): Warn and continue. Board sync is advisory in revision — it does not block the fix pipeline.
+
+---
+
+## Guardrails
+
+- **Never skip ASK checkpoints** (unless auto-advance mode is active for that specific checkpoint).
+- **Never skip the proactive scan (Step 4)** — even if the user reports no issues. Agents leave leftovers.
+- **Always run quality checks (Step 7)** before committing. Never commit code that fails lint, typecheck, or tests.
+- **Stay within the revision scope.** Fix what was reported and what the scan found. Do not refactor unrelated code, add new features, or expand beyond the original implementation's intent.
+- **Always commit and push** at the end of a revision cycle. The user invoked this command to get fixes merged — do not exit without committing (unless the user explicitly abandons).
+- **Respect the original implementation's architecture.** Revision fixes issues within the existing patterns. If the architecture itself is flawed, note it as a finding but do not restructure — suggest a separate refactor instead.
+- **One sub-agent per concern.** Delegate to specialist sub-agents based on finding type. Do not ask the implementer to also fix lint issues or write tests.
+- **Git safety.** Never force-push. Never rewrite history. Always create new commits for revision changes.
+- **This command composes existing hatch3r agents** — it does not replace them. The reviewer, implementer, lint-fixer, and test-writer agents handle the actual work.
+- **Critical findings default to FIX NOW.** If the user overrides this, execute the Critical Deferral Protocol (Step 5b): structured warning with specific risk, require written rationale, record in todo.md with `Critical-deferred` tag, and flag for elevated triage in board-fill. The user is never blocked — rationale adds accountability, not a veto.
+- **Deferred findings go to `todo.md`, not directly to GitHub/GitLab/Azure DevOps issues.** The board-fill pipeline handles triage, epic creation, dependency analysis, and readiness assessment. Revision does not shortcut this process.
+- **Always format deferred items as a single epic block** in `todo.md`, regardless of count. This groups them together during the next board-fill run.

--- a/commands/revision/revision-quality.md
+++ b/commands/revision/revision-quality.md
@@ -1,0 +1,96 @@
+---
+id: hatch3r-revision-quality
+type: command
+description: Quality verification pipeline for revision Step 7. Covers review loop (Stage 1), final quality with conditional specialists (Stage 2), and failure handling.
+tags: [implementation, team]
+quality_charter: agents/shared/quality-charter.md
+---
+# Revision — Quality Verification (Step 7)
+
+Quality pipeline for `hatch3r-revision`. Referenced from the core command file.
+
+Run the project's quality checks after fix implementation. Refer to `package.json` scripts, `README.md`, or `AGENTS.md` for the appropriate commands.
+
+---
+
+## 7a. Run Quality Gates
+
+1. Lint check (e.g., `npm run lint`)
+2. Type check (e.g., `npm run typecheck`)
+3. Test suite (e.g., `npm run test`)
+
+---
+
+## 7b. Verify User-Reported Issues
+
+Walk through each critical and important finding from Step 5. Verify it is addressed by the changes made in Step 6. If acceptance criteria exist from linked issues, verify each criterion.
+
+For each verified finding and acceptance criterion, rate verification confidence: high (fix confirmed via tests or direct observation), medium (code change addresses the issue but edge cases not independently tested), low (fix applied but uncertain of completeness).
+
+---
+
+## Stage 1: Review Loop (Sequential)
+
+Run an iterative review loop (max 3 iterations) until 0 Critical + 0 Warning findings remain:
+
+1. Spawn `hatch3r-reviewer` sub-agent via the Task tool (`subagent_type: "generalPurpose"`).
+
+The reviewer prompt MUST include:
+- The diff of all changes made (use `git diff` on the working tree).
+- All `scope: always` rule directives from `.agents/rules/`.
+- Iteration number and previous findings (if not the first iteration).
+- Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
+
+**When Tier 2/3 research was performed** (from Step 6.pre):
+- Include blast radius data so the reviewer can verify fixes preserve dependent consumers and contracts.
+- Include reference conventions so the reviewer can verify fixes follow established patterns.
+
+2. Process reviewer output:
+   - If **0 Critical and 0 Warning** findings: review loop is clean. Proceed to Stage 2.
+   - If Critical or Warning findings remain: spawn `hatch3r-fixer` sub-agent to address them. When fixes touch shared or public interfaces, include blast radius data and reference conventions in the fixer prompt. Then re-run the reviewer (next iteration).
+
+3. If 3 iterations complete and findings remain, **ASK** the user whether to proceed or fix manually.
+
+After each reviewer iteration, assess the reviewer's findings confidence: if the reviewer rates any finding as low-confidence, flag it separately in the ASK prompt so the user can prioritize human review of uncertain findings.
+
+4. After any fixes, re-run quality gates (7a) to verify nothing broke.
+
+---
+
+## Stage 2: Final Quality (Parallel)
+
+After the review loop is clean, spawn specialist agents in parallel via the Task tool.
+
+### Always Spawn (Mandatory for Code Changes)
+
+- **`hatch3r-test-writer`** — write or update tests for code changes. Unit tests for new logic, regression tests for bug fixes, integration tests for cross-module changes.
+- **`hatch3r-security-auditor`** — security review of code changes. Audit data flows, access control, input validation, and secret management.
+
+### Always Evaluate (Spawn When Applicable)
+
+- **`hatch3r-docs-writer`** — spawn when revision fixes affect public APIs, architectural patterns, or user-facing behavior. Skip silently when no documentation impact is detected (no API signature changes, no UX behavioral changes, no new configuration options).
+
+### Conditional Specialists (Spawn When Triggered)
+
+- **`hatch3r-lint-fixer`** — spawn when lint errors are present after fix implementation (Step 6 lint-fixer may have missed errors introduced by other sub-agents).
+- **`hatch3r-a11y-auditor`** — spawn when the diff includes UI component changes (`area:ui` or `area:a11y` label on linked issues, or component/style files in the diff).
+- **`hatch3r-perf-profiler`** — spawn when the diff includes hot-path changes (`area:performance` label on linked issues, or changes to database queries, API handlers, rendering loops).
+
+### Specialist Prompt Requirements
+
+Each specialist sub-agent prompt MUST include:
+- The agent protocol to follow (e.g., "Follow the hatch3r-test-writer agent protocol").
+- All `scope: always` rule directives from `.agents/rules/` (sub-agents do not inherit rules automatically).
+- The diff or file changes to review.
+- The linked issue's acceptance criteria (if available).
+- Confidence expression requirement: rate every recommendation and finding as high/medium/low confidence per the quality charter (`agents/shared/quality-charter.md`). High = verified against current code. Medium = pattern-based, not fully verified. Low = best judgment, recommend human review.
+
+Await all specialist sub-agents. Apply their feedback (fixes, additional tests, documentation updates). Re-run quality gates (7a) if changes were made.
+
+---
+
+## 7e. Handle Failures
+
+- If quality checks fail: identify the specific failures, fix them directly (for simple issues) or loop back to Step 6 with specific failures.
+- Max 2 retry loops on quality check failures. After 2 retries, **ASK** the user for guidance: "Quality checks still failing. Fix confidence: {high/medium/low — based on whether root cause is identified}."
+- If a user-reported issue was not fully addressed: **ASK** the user whether to attempt another fix or defer.

--- a/docs/adapter-capability-matrix.md
+++ b/docs/adapter-capability-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Capability Matrix
 
-> **Last verified**: 2026-04-10 | **hatch3r version**: 1.5.0
+> **Last verified**: 2026-04-14 | **hatch3r version**: 1.5.1
 
 Living reference for framework capabilities vs. adapter implementations. This document tracks what each adapter emits, what each platform supports natively, and where gaps remain.
 

--- a/governance/EVOLVE.md
+++ b/governance/EVOLVE.md
@@ -1,0 +1,375 @@
+# hatch3r — Evolve Prompt
+
+> Last updated: 2026-04-19
+> Role: Constitutional self-check across the governance corpus, anchored in current-practice web research and the Scientific Rigor Contract. Proposal-only. Modifies no governance file except the report artefact.
+
+## Purpose
+
+Evolve is a governance self-check prompt. It assesses the existing governance files against nine measurable dimensions and emits a proposal report. It does not rewrite the vision, run the framework audit, or modify any governance file aside from its own report artefact. EVOLVE runs standalone — neither a precursor to nor a successor of `governance/AUDIT.md`, and does not block or gate AUDIT runs. EVOLVE assesses the governance corpus; AUDIT assesses the framework output.
+
+**Triggers.**
+- A capability uplift in the executing agent's generation is observed
+- Suspected drift in the governance corpus (lean thresholds exceeded, pillar gaps detected, staleness observed)
+- Periodic cadence — a maximum of 90 days since the prior EVOLVE run
+
+**Run gating.** Minimum 7 days between consecutive EVOLVE runs. A Critical security incident or a regression-gate failure involving governance-scoped artefacts overrides the interval (not the authorization). Authorization: framework owner only.
+
+**North Star.** Evolve serves one mission: keep the governance corpus aligned with the framework's goal of helping teams ship winning real-world software products at any scale through agentic AI. The mission is enumerated as five measurable traits:
+
+1. correctness
+2. security
+3. performance
+4. developer experience per P1 (CLI UX Excellence) in `governance/CONSTITUTION.md` §2
+5. one-shot success rate per `governance/VISION.md` §Quality Bar
+
+Every assessment dimension, every finding, and every proposal is tested against this five-trait mission. A proposal that does not advance a trait with a measurable delta is rejected before ranking (§4.2) and loses ties after ranking (Guardrail 14).
+
+**Out of scope.**
+- Rewriting `governance/VISION.md` — that is `governance/RE-ENVISION.md`
+- Running the 19-domain framework audit — that is `governance/AUDIT.md`
+- Applying governance amendments — those flow through RE-ENVISION, AUDIT-EXECUTE Phase 7 (CL-3), or the Amendment Protocol in `governance/CONSTITUTION.md` §8
+
+---
+
+## §0 — Preflight: Model-Independence Contract
+
+Before any assessment begins, the executing agent accepts this contract.
+
+**The executing agent MUST NOT:**
+- Name its own model family, vendor, or version tier in the prompt trace or in the report
+- Use phrases that presume a specific model capability (e.g., "given my larger context window", "because I can reason harder than prior generations")
+- Refer to specific context-window sizes, token limits, or tokenizer behaviours
+- Mention any model or vendor by name — this includes specific AI labs, named models, and version identifiers
+
+**The executing agent MUST:**
+- Use capability-abstract verbs in its own output: "the executing agent", "the authoring agent", "the reviewing agent", "the sub-agent"
+- Frame capability uplift abstractly: "expanded capability bandwidth", "stronger adherence to structured output schemas", "higher coherence on long-context synthesis"
+- Apply the same forbidden-phrase test to every governance file under review AND to the report it writes
+
+**Forbidden-pattern table** (partial list; extend by analogy):
+
+| Pattern class | Example hits | Acceptable replacement |
+|---|---|---|
+| Tier words | flagship, frontier, premium, top-tier | "expanded capability bandwidth" |
+| Size words | XL, large, small, mini, nano | "the executing agent" (no size) |
+| Generation words | next-gen, latest, newest | "a capability uplift over the prior generation" |
+| Brand / vendor | any AI lab name | "the executing agent's generation" |
+| Model-ID pattern | version suffix digits, tag strings | (remove entirely) |
+| Context-window size | token-count figures | "long-context synthesis" |
+| Token / tokenizer terms | budget-in-tokens, byte-pair-encoding | (remove entirely) |
+
+**Future-proofing clause.** If a term enters common usage after this document was written that maps to model tier / size / generation / vendor identity, the executing agent MUST treat it as a banned pattern by analogy and MUST record the decision in the Metadata section of the run's report.
+
+**File-path exception.** Strings inside backticks that name files in this repository (e.g., adapter-output filenames whose names happen to be derived from vendor or product identifiers) are factual references to repository files, not self-identification by the executing agent. They are exempt from the name-ban in this contract.
+
+The report artefact is `governance/EVOLVE-REPORT.md`. The prompt writes no other file.
+
+### Web Research Mandate
+
+The executing agent performs targeted web research before proposal generation. Required topics:
+
+- Leading agentic-coding framework practice (what changed since the prior EVOLVE run)
+- Prompt-engineering and agent-orchestration research — published literature, vendor technical notes, independent benchmarks
+- Platform documentation for the 15 adapters hatch3r ships — freshness versus the adapter source files
+- Security baselines — OWASP ASI current revision, supply-chain threat reports, agentic-security advisories
+- Industry UI and UX patterns for developer tools — CLI, IDE-integrated assistants, and review surfaces
+- Performance and cost benchmarks relevant to agentic workflows at the scales the framework targets
+
+**Rigor requirements.** (1) At least 2 independent sources per topic. (2) Citation format: URL + access date + author/organisation + trust tier, where trust tier is one of (highest to lowest): official-docs, peer-reviewed, vendor-note, independent-analysis, blog-post. (3) Recency windows: technology and platform-documentation claims ≤12 months; published research ≤36 months. (4) Paywalled sources: accepted only if a public summary or secondary citation is available; otherwise the dependent claim downgrades to Low confidence. (5) Withdrawn / 404 sources: trigger a re-research pass before the run completes. A proposal invoking current practice without citations meeting the above is rejected before inclusion.
+
+### Scientific Rigor Contract
+
+Every finding and every proposal satisfies six tests drawn from established empirical practice:
+
+1. **Falsifiability (Popper).** Record the observation that would disprove the finding. A non-falsifiable claim is rejected.
+2. **Citation and triangulation.** Every empirical claim references a source — file path plus line, URL plus access date, or a named principle. Where the claim depends on external state, triangulate across at least two independent sources.
+3. **Confidence expression.** Express as High / Medium / Low with the basis — direct measurement, sampled observation, inference from analogue. Overclaiming confidence is itself a finding.
+4. **Root-cause orientation.** Distinguish symptom from systemic driver using at minimum a three-step causal chain. Symptomatic fixes ship as Info; the systemic driver is the Medium-or-higher finding.
+5. **Bias check.** Name the specific bias risks that apply to the finding — confirmation, availability, anchoring — and flag any finding that depends on prior EVOLVE-report framing. A finding that cannot pass this check is downgraded one severity band.
+6. **Adversarial peer-review pass.** Before inclusion, re-read each finding as a sceptic and record one genuine counter-argument; resolution of the counter-argument appears in the finding body.
+
+A finding or proposal missing any of the six tests is rejected before inclusion.
+
+---
+
+## §1 — Pre-Assessment: Load and Inventory
+
+### 1.1 Enumerate in-scope files
+
+Load and record line counts plus `Last updated` headers for:
+- `governance/VISION.md`
+- `governance/CONSTITUTION.md`
+- `governance/AUDIT.md`
+- `governance/AUDIT-EXECUTE.md`
+- `governance/RE-ENVISION.md`
+- `governance/EVOLVE.md` (this prompt; self-review in scope; processed first per §2)
+- Every file matching `governance/audit/domains/D*.md`
+- Every file matching `governance/audit/templates/*.md`
+
+**Explicitly out of scope, with rationale:** the gitignored PRD (`governance/hatch3r-prd.md`) and competitive analysis (`governance/COMPETITIVE-ANALYSIS.md`) carry operational detail and market context; state files (`governance/audit/finding-registry.json`, `governance/audit/execution-insights.json`, `governance/audit/baseline.json`) are per-run mutable data, not governance prompt content; `CLAUDE.md` and `.claude/*` are dev-setup for building hatch3r, not framework-governance; the canonical content corpus (`agents/`, `skills/`, `rules/`, `commands/`, `hooks/`, `checks/`, `prompts/`, `github-agents/`) is the responsibility of `governance/AUDIT.md` domains D1, D5, D9, and D19, not EVOLVE.
+
+### 1.2 Record inventory
+
+For each file, record: line count, `Last updated` date if present, pillar references found in the first 30 lines, and whether the file is a prompt (directive) or documentation (descriptive).
+
+### 1.3 Load authoritative references BY REFERENCE
+
+The prompt does not restate these. It reads them from source:
+- Six Binding Pillars (P1–P6): `governance/CONSTITUTION.md` §2
+- Lean thresholds table: `governance/CONSTITUTION.md` §2 Lean Thresholds
+- Pillar Compliance Test: `governance/CONSTITUTION.md` §2
+- Pillar-to-Governance Traceability Matrix: `governance/CONSTITUTION.md` §3
+- Anti-slop wordlist: `governance/AUDIT-EXECUTE.md` regression gate check 10
+- Severity conventions (Critical / High / Medium / Info): `governance/AUDIT.md` §Scoring Methodology
+- Amendment Protocol: `governance/CONSTITUTION.md` §8
+
+### 1.4 ASK — Gate 1: scope confirmation
+
+Present the inventory table and the explicit out-of-scope rationale. Ask:
+
+> Proceed with all files in scope? (y/n) If n, list files to exclude from this run.
+
+Hard stop. Do not proceed without an explicit response.
+
+---
+
+## §2 — Per-File Assessment: Nine Dimensions
+
+For every in-scope file, the executing agent runs the nine-dimension checklist. `governance/EVOLVE.md` is processed first so the self-check is on record before any other file biases the assessment. Domain and template files are processed in a loop using one shared template, and broken out individually only when a specific file has Critical or High findings.
+
+### 2.1 Assessment dimensions
+
+For each file, record a row per dimension: **verdict** (Pass / Partial / Fail), **evidence** (quoted phrase or section reference), **severity** (Critical / High / Medium / Info).
+
+1. **Pillar alignment (P1–P6).** Does the file declare which pillars it serves? Is every section traceable to at least one pillar? Orphan content is a Medium finding.
+2. **Lean threshold compliance.** Is the line count within the threshold defined in `governance/CONSTITUTION.md` §2 Lean Thresholds? Overage without a pillar-backed rationale is a High finding.
+3. **Anti-slop compliance.** Apply the wordlist from `governance/AUDIT-EXECUTE.md` regression gate check 10. Each unqualified hit is a Medium finding. Count and list phrase-by-phrase.
+4. **Cross-file duplication.** Identify paragraphs, tables, or lists that restate concepts owned by another governance file. Reference over restatement is the target. Greater than 5% concept-level duplication across a pair is a High finding.
+5. **Model-portability.** Scan for model or vendor or family names, version identifiers, capability-tier phrasing, and context-window-specific instructions. Any hit in a prompt file is a Critical finding; in documentation, Medium. The §0 contract and forbidden-pattern table apply.
+6. **Currency.** Compute days since the file's `Last updated` header. Greater than 180 days is a Medium finding. A missing header is a Low finding. Prose date references that now lie in the past are Low findings.
+7. **Pillar coverage contribution.** Cross-reference the file's claimed pillars against the Pillar-to-Governance Traceability Matrix in `governance/CONSTITUTION.md` §3. Drift between the claim and the matrix is a Medium finding.
+8. **Capability-leverage opportunities.** Identify sections where increased execution capability would permit simplification (fewer sub-steps), consolidation (merged overlapping sub-agents), or expansion (new checks previously too costly). State opportunities in capability-abstract terms per §0. Each opportunity is Info severity.
+9. **North Star contribution.** Does the file advance at least one enumerated North Star trait (correctness, security, performance, developer experience per P1, one-shot success rate per VISION.md §Quality Bar)? Absent contribution on a file whose stated role implies such capability is a Medium finding; a false claim of capability is a High finding.
+
+**Intentionally out of scope as EVOLVE dimensions** (each is owned by an AUDIT.md domain, not EVOLVE): adapter parity (D9), onboarding quality (D10), accessibility (D10), distribution readiness (D18), economic viability (D18), community-contribution friction (D10, D18), performance-under-load (D1, D3, D4).
+
+### 2.2 Per-file output structure
+
+Each file receives a sub-section in the report:
+
+```
+### <file-path>
+| Dimension | Verdict | Evidence | Severity |
+|-----------|---------|----------|----------|
+| Pillar alignment | ... | ... | ... |
+| Lean threshold | ... | ... | ... |
+| Anti-slop | ... | ... | ... |
+| Cross-file duplication | ... | ... | ... |
+| Model-portability | ... | ... | ... |
+| Currency | ... | ... | ... |
+| Pillar coverage | ... | ... | ... |
+| Capability-leverage | ... | ... | ... |
+| North Star contribution | ... | ... | ... |
+```
+
+Domain and template files collapse into a single summary table with one row per file when findings are uniform. Any file with a Critical or High finding gets its own full sub-section.
+
+---
+
+## §3 — Cross-File Synthesis
+
+### 3.1 Pairwise duplication matrix
+
+Produce an NxN matrix across all in-scope files. Each cell shows estimated concept-level overlap as a percentage. Target <5% per pair. Flag pairs over 5% as High findings and list the overlapping concept.
+
+### 3.2 Pillar coverage redraw
+
+Redraw the Pillar-to-Governance Traceability Matrix (rows = P1–P6, columns = in-scope files) based on the pillar references recorded in Step 1.2. Compare cell-by-cell against `governance/CONSTITUTION.md` §3. Flag any pillar with no file coverage; flag any file serving zero pillars.
+
+### 3.3 Currency summary
+
+One row per file: `Last updated`, days stale, verdict. Sort by staleness descending.
+
+### 3.4 Capability-leverage summary
+
+One row per opportunity: file, section, current approach, capability-abstract description of the uplift that would enable simplification or consolidation. No model names. No tier / size / generation words.
+
+---
+
+## §4 — Proposal Generation
+
+### ASK — Gate 2: pre-web-research confirmation
+
+Before running web research, present the six topics and the ≥2-independent-sources rule. Ask:
+
+> Proceed with web research on all six topics? (y/n) If n, list topics to drop or narrow.
+
+Hard stop.
+
+### ASK — Gate 3: pre-proposal confirmation
+
+After findings are captured but before proposals are ranked, present the findings set and any rejection-filter hits from §4.2. Ask:
+
+> Proceed to rank and generate proposals from the presented findings set? (y/n) If n, list findings to exclude.
+
+Hard stop.
+
+Generate at most **15 proposals per run**. Rank by the formula:
+
+```
+rank_score = severity_weight × pillar_impact × north_star_multiplier
+  severity_weight      = Critical:25, High:10, Medium:3, Info:1
+  pillar_impact        = count of pillars served (1–6)
+  north_star_multiplier = 1.5 if proposal advances a named North Star trait
+                          with a measurable delta, else 1.0
+```
+
+Drop the tail beyond the 15-proposal cap.
+
+### 4.1 Proposal schema
+
+Every proposal records:
+
+- **Proposal ID.** Sequential integer within the run.
+- **Target file.** Exact repository-relative path.
+- **Current state.** Quoted passage or section reference.
+- **Proposed change.** Diff-style description (add / remove / rewrite).
+- **Pillar served.** One or more of P1–P6.
+- **North Star trait advanced.** One or more of the five enumerated traits, with the measurable delta stated.
+- **Line delta.** Estimated +/- lines.
+- **Routing recommendation.** Route A, B, or C (see §6).
+- **Pillar Compliance Test answers.** Three answers per `governance/CONSTITUTION.md` §2: which pillar(s), what measurable improvement, net size impact (with justification if an increase).
+
+### 4.2 Rejection filters
+
+A proposal is rejected before inclusion if any of these hold:
+
+- It cannot answer all three Pillar Compliance Test questions
+- It does not advance at least one enumerated North Star trait
+- It proposes an operational-detail change — release dates, version numbers, command flags, CI workflow tweaks; those belong in PRD
+- It proposes a change to EVOLVE.md that would remove the Model-Independence Contract in §0 or the guardrails in §7
+- It proposes auto-apply semantics — this prompt is proposal-only by design
+- Its core claim is not measurable (no quantified threshold, no falsifiable delta)
+- It duplicates a finding currently open in the active audit cycle (check the most recent `governance/AUDIT-REPORT.md` if present; if the report is ephemeral per Guardrail 9 and absent, the filter does not fire)
+- It depends on infrastructure not yet present in the repository (uncommitted file paths, proposed-but-not-adopted schemas)
+
+---
+
+## §5 — Report Assembly
+
+### 5.1 Compose the report
+
+Compose `governance/EVOLVE-REPORT.md` with these sections:
+
+1. **Executive Summary.** File count; findings by severity; routing split (A / B / C); governance total line count versus the 3000-line budget; trigger that fired for this run; authorizer; North Star advancement summary (traits touched by accepted proposals); any *Self-Critical Caveat* block per the Self-Assessment Semantics section below.
+2. **Per-File Assessment.** §2 output, one sub-section per file, self-row first.
+3. **Cross-File Synthesis.** §3 output — duplication matrix, pillar coverage delta, currency summary, capability-leverage summary.
+4. **Web Research Citations.** Consolidated table — one row per source: URL, access date, author/organisation, trust tier, topic served, recency check verdict.
+5. **Findings Log.** One row per finding with falsifiability statement, citation(s), confidence (H/M/L), causal-chain depth, bias-check result, adversarial peer-review counter-argument, confidence-downgrade flag if any.
+6. **Proposals.** §4 output, at most 15.
+7. **Routing Map.** §6 output — one table row per proposal under each route; multi-route splits recorded.
+8. **Metadata.** Inventory timestamps; pinned `governance/CONSTITUTION.md` commit hash; assessment-dimensions version; prompt-file SHA at run start; trigger; authorizer; run-id; any forbidden-pattern-by-analogy decisions recorded per §0.
+
+### 5.2 Self-audit pass
+
+Before writing the report, scan the composed content for: model / vendor / family names; capability-tier, tier-word, size-word, generation-word, or context-window phrasing tied to a specific generation; anti-slop wordlist hits from `governance/AUDIT-EXECUTE.md` regression gate check 10; operational-detail proposals that slipped past the §4.2 filter. Rewrite or remove every hit. Repeat the scan until zero hits remain.
+
+### 5.3 ASK — Gate 4: report write confirmation
+
+Present the target path (`governance/EVOLVE-REPORT.md`) and overwrite intent, including any *Self-Critical Caveat*. Ask:
+
+> Write the report to `governance/EVOLVE-REPORT.md`, overwriting any existing file at that path? (y/n)
+
+Hard stop.
+
+### 5.4 Write
+
+On confirmation, write the report. Modify no other file.
+
+---
+
+## §6 — Handoff and Routing
+
+Every proposal is routed to exactly one of three buckets. The report's routing table lists each proposal under its route with the next-prompt handoff.
+
+**Route A — Vision and principles.** Any proposal that touches `governance/VISION.md` content: identity, audience, quality bar, principles, platform strategy, lifecycle coverage. Next prompt: `governance/RE-ENVISION.md` used as a tool. The proposal flows through RE-ENVISION's themed-dialog refinement.
+
+**Route B — Audit system.** Any proposal that touches `governance/AUDIT.md`, `governance/AUDIT-EXECUTE.md`, `governance/audit/domains/D*.md`, or `governance/audit/templates/*.md`: sub-agent counts, domain weights, scoring methodology, behavioral charter, regression gates, waves, closed-loop phases, template content. Next prompt: `governance/AUDIT-EXECUTE.md` Phase 7 (Audit Prompt Evolution / CL-3). The proposal is presented per-item for user consent.
+
+**Route C — Constitution and prompt mechanics.** Any proposal that touches `governance/CONSTITUTION.md`, `governance/RE-ENVISION.md` *as an artefact to edit* (prompt mechanics of RE-ENVISION itself, not vision content), or `governance/EVOLVE.md` itself: pillar wording, lean thresholds, anti-slop wordlist, Pillar Compliance Test, prompt mechanics. Next action: direct edit under the Amendment Protocol in `governance/CONSTITUTION.md` §8 with a dated rationale.
+
+**RE-ENVISION.md dual-role — worked example.** A proposal to clarify VISION.md's audience list → Route A (RE-ENVISION.md used as a tool to rewrite VISION content). A proposal to add a new theme-block question to RE-ENVISION.md's §2 dialog → Route C (editing RE-ENVISION.md's own prompt mechanics). The destination of the change — VISION content vs RE-ENVISION mechanics — distinguishes the route.
+
+**Multi-route conflict resolution.** If a proposal targets files in multiple routes, split it into per-route sub-proposals so each sub-proposal is routed independently. If the proposal is atomic and cannot be split, route to the highest-risk route in precedence order C → B → A — the most restrictive amendment path governs.
+
+### 6.1 Routing table
+
+```
+| Route | Proposal IDs | Next Prompt / Action                              |
+|-------|--------------|---------------------------------------------------|
+| A     | ...          | governance/RE-ENVISION.md                         |
+| B     | ...          | governance/AUDIT-EXECUTE.md Phase 7 (CL-3)        |
+| C     | ...          | Direct edit under governance/CONSTITUTION.md §8   |
+```
+
+After writing the routing table and naming the next prompt per bucket, the prompt stops. EVOLVE does not invoke any downstream prompt.
+
+---
+
+## §7 — Guardrails
+
+1. **No governance modification.** The only file this prompt writes is `governance/EVOLVE-REPORT.md`. Every other governance file is read-only throughout the run. The ban is absolute; any change to EVOLVE.md itself flows through Route C.
+2. **ASK gates are non-negotiable.** Four hard-stop gates: Step 1.4 (scope confirmation), §4 pre-web-research gate, §4 pre-proposal gate, Step 5.3 (report write confirmation). The prompt halts at each gate and waits for an explicit response. No timed default-yes.
+3. **Maximum 15 proposals per run.** Overflow is dropped by the rank formula in §4. The prompt does not batch overflow into a "part 2" report.
+4. **Pillar Compliance Test is mandatory per proposal.** A proposal missing any of the three answers from `governance/CONSTITUTION.md` §2 is rejected before inclusion.
+5. **Model-Independence Contract applies to prompt and report.** The Step 5.2 self-audit removes every violation before write. A hit in the report is a blocker; the report does not ship with any hit.
+6. **Operational details are out of scope.** Release dates, version numbers, command flags, CI workflow tweaks — those belong in PRD or repository configuration, not in governance proposals.
+7. **No amendment authority.** Proposals are proposals. Routes A, B, and C flow through existing mechanisms — RE-ENVISION, AUDIT-EXECUTE Phase 7, and `governance/CONSTITUTION.md` §8 Amendment Protocol respectively. EVOLVE does not claim to amend any governance file.
+8. **Missing file equals recorded gap, not abort.** If an in-scope file is missing from the filesystem, the prompt records the gap as a Critical finding in Per-File Assessment and continues with the remaining files.
+9. **Report is ephemeral.** Each run overwrites `governance/EVOLVE-REPORT.md`. `governance/EVOLVE-REPORT.md` is listed in `.gitignore` so the report never enters version control. No historical retention — prior runs are lost on overwrite. This is intentional per Guardrail 11 (no cross-run state); cross-run analysis would violate that guardrail.
+10. **No duplication of source-of-truth content.** Pillars, lean thresholds, anti-slop wordlist, Pillar Compliance Test, severity conventions, and the Traceability Matrix are referenced by file path and section, never restated. Restatement within EVOLVE.md is itself a High finding this prompt would raise against itself.
+11. **No cross-run state.** EVOLVE does not read a prior `EVOLVE-REPORT.md` to decide what to include in the current run. Each run is stateless against the current filesystem state of `governance/`.
+12. **No invocation of downstream prompts.** EVOLVE stops after writing the report and printing the routing table. The user triggers RE-ENVISION, AUDIT-EXECUTE, or direct edits as follow-up actions.
+13. **Web research and scientific rigor are non-negotiable.** Every finding carries a falsifiability statement, triangulated citations meeting the Web Research Mandate rigor requirements in §0, a confidence level, a root-cause chain of at least three steps, a bias check, and an adversarial peer-review counter-argument. Every current-practice claim carries URL + access date + author/org + trust tier. Missing any disqualifies the finding from inclusion.
+14. **North Star is both an upstream gate and the tiebreaker.** A proposal that fails to advance at least one enumerated North Star trait is rejected at §4.2. When two accepted proposals conflict or when prioritisation is ambiguous, the proposal that better advances the framework's ability to ship winning real-world software at any scale wins. Internal elegance without mission impact loses.
+15. **Run gating.** Minimum 7 days between consecutive EVOLVE runs; framework-owner authorization required; a Critical security incident or a regression-gate failure involving governance-scoped artefacts overrides the interval but not the authorization.
+16. **Forbidden-pattern extension by analogy.** Any term that maps to model tier / size / generation / vendor identity is banned even if introduced after this prompt was written. Each such decision is recorded in the report's Metadata section.
+
+---
+
+## Self-Assessment Semantics
+
+`governance/EVOLVE.md` is processed first in §2 so the self-check is on record before any other file biases the assessment.
+
+- On a **self-Medium, self-Low, or self-Info** finding: the run proceeds normally; the self-row is reported in Per-File Assessment as for any other file.
+- On a **self-High** finding: reported normally. The run proceeds.
+- On a **self-Critical** finding: the run **does not halt**. Instead, the Executive Summary opens with a *Self-Critical Caveat* block naming the finding, restating that Guardrail 1 forbids in-run self-edit, and identifying the Route C proposal that must be adopted before the next EVOLVE run. The Step 5.3 ASK gate repeats the caveat so the user has an explicit choice.
+
+---
+
+## Pillar Service Declaration
+
+This prompt serves the framework's North Star through the following pillars:
+
+- **P5 Governance Self-Quality (primary).** Structural self-check across nine measurable dimensions; surfaces drift that today has no other owner.
+- **P4 Comprehensive Lean Coverage (supporting).** Pairwise duplication matrix, pillar-gap detection, and per-file lean-threshold verification.
+- **P2 Scientific & Practical Quality (supporting).** Enforces the six-test Scientific Rigor Contract in §0 — falsifiability, citation, confidence expression, root-cause orientation, bias check, adversarial peer-review — on every finding and proposal.
+- **P3 Adapter & MCP Currency (supporting).** Enforces the Web Research Mandate in §0 — proposals that invoke current practice carry URL + access date + author/org + trust tier citations.
+
+**Pillar Compliance Test answers for this prompt file:** (1) Serves P5 primary plus P4, P2, P3 supporting. (2) Measurable improvement — surfaces drift in the governance corpus via the nine-dimension checklist and routes every actionable proposal to one of three defined amendment mechanisms; rejects proposals failing the Scientific Rigor Contract or Pillar Compliance Test so the governance system stays testable. (3) Yes, it increases governance size by roughly the line count of this file; net value exceeds cost because no other prompt owns constitutional self-check against current practice — absent this prompt, drift surfaces only incidentally during full audits (D16, D18, D19) where governance attention competes with framework-output findings.
+
+This prompt is itself subject to the nine-dimension checklist in §2 and to the Scientific Rigor Contract in §0. Each run records a self-assessment row for `governance/EVOLVE.md` in the Per-File Assessment output.
+
+---
+
+## Follow-Up Items (Out of This Session's Write Scope)
+
+The following are recorded as candidates for a later direct edit under the Amendment Protocol (Route C) or a separate dev-cycle task. This session modifies only `governance/EVOLVE.md`.
+
+- Add an `EVOLVE.md` row to the Lean Thresholds table in `governance/CONSTITUTION.md` §2 P5 and mirror into `CLAUDE.md` §Lean Thresholds. Proposed line cap: 400, with per-section sub-budgets matching the structure of this prompt.
+- Add an `EVOLVE.md` row to the Governance References table in `CLAUDE.md`.
+- Consider authoring `.claude/skills/hatch3r-evolve/SKILL.md` so EVOLVE can be invoked via a dev-side slash command. EVOLVE.md remains directly invokable as a prompt without the wrapper.
+
+---
+
+> End of prompt. Executing agent: stop here. Do not continue into downstream routes. The report is written. The routing table is printed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatch3r",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatch3r",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatch3r",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Battle-tested agentic coding setup framework. One command to hatch your agent stack -- agents, skills, rules, commands, and MCP for every major AI coding tool.",
   "type": "module",
   "exports": {

--- a/src/__tests__/cli/config.test.ts
+++ b/src/__tests__/cli/config.test.ts
@@ -42,6 +42,23 @@ vi.mock("../../content/index.js", () => ({
     hook: "hooks",
     "github-agent": "githubAgents",
   },
+  resolveSelection: vi.fn().mockReturnValue({
+    preset: "full", projectType: "brownfield", teamSize: "team",
+    items: { agents: [], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+  }),
+  countPresetExclusions: vi.fn().mockReturnValue(0),
+  estimatePresetItemCount: vi.fn().mockReturnValue(50),
+  getAllContentIds: vi.fn().mockReturnValue(new Set<string>()),
+}));
+
+vi.mock("../../content/presets.js", () => ({
+  PRESETS: [
+    { id: "minimal", name: "Minimal", description: "Core only", includeTags: ["core"], excludeTags: [] },
+    { id: "standard", name: "Standard", description: "Full dev lifecycle", includeTags: [], excludeTags: [] },
+    { id: "full", name: "Full (recommended)", description: "Everything", includeTags: [], excludeTags: [] },
+    { id: "custom", name: "Custom", description: "Choose exactly what you need", includeTags: [], excludeTags: [] },
+  ],
+  getPreset: vi.fn().mockReturnValue({ id: "full", name: "Full (recommended)", description: "Everything", includeTags: [], excludeTags: [] }),
 }));
 
 vi.mock("../../cli/shared/agentsContent.js", () => ({
@@ -106,7 +123,10 @@ import {
   selectionSummary,
   extractContentReferences,
   validateOrchestrationDependencies,
+  resolveSelection,
+  getAllContentIds,
 } from "../../content/index.js";
+import { getPreset } from "../../content/presets.js";
 import { generateCanonicalAgentsMd, generateRootAgentsMd } from "../../cli/shared/agentsContent.js";
 import { safeWriteFile } from "../../merge/safeWrite.js";
 import { ensureEnvMcp, ensureGitignoreEntry, getSourceEnvMcpCommand } from "../../env/mcpEnv.js";
@@ -169,7 +189,7 @@ function makeContentSelection(overrides: Partial<ContentSelection> = {}): Conten
 
 /**
  * Set up the standard prompt sequence for configCommand:
- * platform -> repo identity -> branch -> tools -> features -> mcp -> content manage
+ * platform -> repo identity -> branch -> tools -> features -> mcp -> content preset [-> custom items]
  */
 function setupStandardPrompts(
   manifest: HatchManifest,
@@ -180,7 +200,7 @@ function setupStandardPrompts(
     tools?: string[];
     features?: (keyof Features)[];
     mcpServers?: string[];
-    manageContent?: boolean;
+    contentPreset?: string;
     contentItems?: string[];
   } = {},
 ): void {
@@ -236,14 +256,14 @@ function setupStandardPrompts(
     });
   }
 
-  // 7. Content management prompt (only if manifest has content)
+  // 7. Content preset selection prompt (only if manifest has content)
   if (manifest.content) {
     inquirerMock.prompt.mockResolvedValueOnce({
-      manage: overrides.manageContent ?? false,
+      preset: overrides.contentPreset ?? manifest.content.preset ?? "full",
     });
 
-    // 8. Content items prompt (only if manage=true)
-    if (overrides.manageContent) {
+    // 8. Custom items prompt (only if preset is "custom")
+    if (overrides.contentPreset === "custom") {
       inquirerMock.prompt.mockResolvedValueOnce({
         items: overrides.contentItems ?? [],
       });
@@ -640,7 +660,7 @@ describe("config command", () => {
   // ── Content management ───────────────────────────────────────
 
   describe("content management", () => {
-    it("should skip content when user declines to manage", async () => {
+    it("should use preset selection for content management", async () => {
       const manifest = makeManifest({
         content: makeContentSelection({
           items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
@@ -649,15 +669,32 @@ describe("config command", () => {
       vi.mocked(readManifest).mockResolvedValue(manifest);
       vi.mocked(countSelectionItems).mockReturnValue(1);
       vi.mocked(selectionSummary).mockReturnValue("1 agents");
-      setupStandardPrompts(manifest, { manageContent: false });
+
+      const mockIndex = {
+        items: [
+          { id: "hatch3r-implementer", type: "agent", description: "Implementer", tags: [], relativePath: "agents/hatch3r-implementer.md" },
+        ],
+        byType: {},
+        byId: new Map([
+          ["hatch3r-implementer", { id: "hatch3r-implementer", type: "agent", description: "Implementer", tags: [], relativePath: "agents/hatch3r-implementer.md" }],
+        ]),
+      };
+      vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
+      vi.mocked(getAllContentIds).mockReturnValue(new Set(["hatch3r-implementer"]));
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
 
-      expect(vi.mocked(buildContentIndex)).not.toHaveBeenCalled();
+      expect(vi.mocked(buildContentIndex)).toHaveBeenCalled();
+      expect(vi.mocked(resolveSelection)).toHaveBeenCalled();
     });
 
-    it("should add new content items when selected", async () => {
+    it("should add new content items when preset resolves additional items", async () => {
       const contentItems = makeContentSelection({
         items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
       });
@@ -679,10 +716,18 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer", "hatch3r-reviewer"],
+      // Old selection has implementer, new selection adds reviewer
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer"]); // old
+        return new Set(["hatch3r-implementer", "hatch3r-reviewer"]); // new
       });
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        items: { agents: ["hatch3r-implementer", "hatch3r-reviewer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -694,7 +739,7 @@ describe("config command", () => {
       );
     });
 
-    it("should remove deselected content items", async () => {
+    it("should remove content items when preset resolves fewer items", async () => {
       const contentItems = makeContentSelection({
         items: { agents: ["hatch3r-implementer", "hatch3r-reviewer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
       });
@@ -716,10 +761,19 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer"],
+      // Old has both, new only has implementer
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer", "hatch3r-reviewer"]); // old
+        return new Set(["hatch3r-implementer"]); // new
       });
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        preset: "minimal",
+        items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest, { contentPreset: "minimal" });
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -731,7 +785,7 @@ describe("config command", () => {
       );
     });
 
-    it("should update manifest content items after content changes", async () => {
+    it("should update manifest content after preset change", async () => {
       const contentItems = makeContentSelection({
         items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
       });
@@ -753,10 +807,18 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer", "hatch3r-test-writer"],
+      const newSelection = makeContentSelection({
+        items: { agents: ["hatch3r-implementer", "hatch3r-test-writer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
       });
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer"]); // old
+        return new Set(["hatch3r-implementer", "hatch3r-test-writer"]); // new
+      });
+      vi.mocked(resolveSelection).mockReturnValue(newSelection);
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -789,10 +851,17 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer", "hatch3r-reviewer"],
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer"]); // old
+        return new Set(["hatch3r-implementer", "hatch3r-reviewer"]); // new
       });
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        items: { agents: ["hatch3r-implementer", "hatch3r-reviewer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -824,10 +893,13 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer"],
-      });
+      // Both old and new resolve to the same set — no changes
+      vi.mocked(getAllContentIds).mockReturnValue(new Set(["hatch3r-implementer"]));
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -1087,10 +1159,17 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer", "hatch3r-reviewer"],
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer"]);
+        return new Set(["hatch3r-implementer", "hatch3r-reviewer"]);
       });
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        items: { agents: ["hatch3r-implementer", "hatch3r-reviewer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest);
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();
@@ -1283,10 +1362,18 @@ describe("config command", () => {
       };
       vi.mocked(buildContentIndex).mockResolvedValue(mockIndex as any);
 
-      setupStandardPrompts(manifest, {
-        manageContent: true,
-        contentItems: ["hatch3r-implementer"],
+      let callCount = 0;
+      vi.mocked(getAllContentIds).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) return new Set(["hatch3r-implementer", "hatch3r-reviewer"]);
+        return new Set(["hatch3r-implementer"]);
       });
+      vi.mocked(resolveSelection).mockReturnValue(makeContentSelection({
+        preset: "minimal",
+        items: { agents: ["hatch3r-implementer"], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
+      }));
+
+      setupStandardPrompts(manifest, { contentPreset: "minimal" });
 
       const { configCommand } = await import("../../cli/commands/config.js");
       await configCommand();

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -52,7 +52,7 @@ describe("init command", () => {
     const manifest = JSON.parse(raw);
 
     expect(manifest.version).toBe("2.0.0");
-    expect(manifest.hatch3rVersion).toBe("1.5.0");
+    expect(manifest.hatch3rVersion).toBe("1.5.1");
     expect(manifest.platform).toBe("github");
     expect(Array.isArray(manifest.tools)).toBe(true);
     expect(manifest.tools.length).toBeGreaterThan(0);
@@ -192,7 +192,7 @@ describe("init command", () => {
     await initCommand({ yes: true });
 
     const manifest = JSON.parse(await readFile(join(agentsDir, "hatch.json"), "utf-8"));
-    expect(manifest.hatch3rVersion).toBe("1.5.0");
+    expect(manifest.hatch3rVersion).toBe("1.5.1");
   });
 
   it("should include AGENTS.md in managedFiles", async () => {
@@ -285,15 +285,15 @@ describe("init command", () => {
     expect(manifest.tools).toEqual(["amp"]);
   });
 
-  it("should use standard preset by default with --yes flag", async () => {
+  it("should use full preset by default with --yes flag", async () => {
     await initCommand({ yes: true });
 
     const manifestPath = join(tempDir, AGENTS_DIR, "hatch.json");
     const manifest = JSON.parse(await readFile(manifestPath, "utf-8"));
 
-    // In --yes mode, content.preset should default to standard
+    // In --yes mode, content.preset should default to full
     if (manifest.content) {
-      expect(manifest.content.preset).toBe("standard");
+      expect(manifest.content.preset).toBe("full");
     }
   });
 

--- a/src/__tests__/cli/lifecycle.test.ts
+++ b/src/__tests__/cli/lifecycle.test.ts
@@ -88,7 +88,7 @@ describe("init -> sync -> update lifecycle", () => {
     // Verify update refreshed the manifest version
     const updatedManifestRaw = await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8");
     const updatedManifest = JSON.parse(updatedManifestRaw);
-    expect(updatedManifest.hatch3rVersion).toBe("1.5.0");
+    expect(updatedManifest.hatch3rVersion).toBe("1.5.1");
 
     // Verify adapter output was regenerated
     const updatedBridge = await readFile(bridgePath, "utf-8").catch(() => null);

--- a/src/__tests__/cli/migration-checkpoints.test.ts
+++ b/src/__tests__/cli/migration-checkpoints.test.ts
@@ -267,7 +267,7 @@ describe("migration checkpoints", () => {
   describe("fully migrated manifest", () => {
     it("should trigger no checkpoints when manifest is complete", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.5.0",
+        hatch3rVersion: "1.5.1",
         platform: "github",
         content: makeContentSelection(),
       });
@@ -436,7 +436,7 @@ describe("migration checkpoints", () => {
 
       const manifestPath = join(tempDir, AGENTS_DIR, "hatch.json");
       const updated = JSON.parse(await readFile(manifestPath, "utf-8"));
-      expect(updated.hatch3rVersion).toBe("1.5.0");
+      expect(updated.hatch3rVersion).toBe("1.5.1");
 
       const allOutput = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(allOutput).toContain("Update complete");
@@ -447,7 +447,7 @@ describe("migration checkpoints", () => {
   describe("update flow when manifest is already up-to-date", () => {
     it("should note already at latest version and still complete update", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.5.0",
+        hatch3rVersion: "1.5.1",
         platform: "github",
         content: makeContentSelection(),
       });

--- a/src/__tests__/cli/update.test.ts
+++ b/src/__tests__/cli/update.test.ts
@@ -112,7 +112,7 @@ describe("update command", () => {
     const manifest = JSON.parse(
       await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"),
     );
-    expect(manifest.hatch3rVersion).toBe("1.5.0");
+    expect(manifest.hatch3rVersion).toBe("1.5.1");
   });
 
   it("should copy hatch3r-prefixed files from pack", async () => {
@@ -164,7 +164,7 @@ describe("update command", () => {
   });
 
   it("should note when already at latest version", async () => {
-    await createTestProject(tempDir, { hatch3rVersion: "1.5.0" });
+    await createTestProject(tempDir, { hatch3rVersion: "1.5.1" });
 
     const { updateCommand } = await import("../../cli/commands/update.js");
     await updateCommand({ backup: false });

--- a/src/__tests__/manifest/hatchJson.test.ts
+++ b/src/__tests__/manifest/hatchJson.test.ts
@@ -11,7 +11,7 @@ describe("hatchJson", () => {
         tools: ["cursor"],
       });
       expect(manifest.version).toBe("2.0.0");
-      expect(manifest.hatch3rVersion).toBe("1.5.0");
+      expect(manifest.hatch3rVersion).toBe("1.5.1");
       expect(manifest.platform).toBe("github");
       expect(manifest.tools).toEqual(["cursor"]);
       expect(manifest.features.agents).toBe(true);

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -352,6 +352,7 @@ export async function configCommand(): Promise<void> {
 
   // --- Content management ---
   const contentChanges: { added: Array<{ type: string; id: string }>; removed: Array<{ type: string; id: string }> } = { added: [], removed: [] };
+  let contentMetadataChanged = false;
   if (manifest.content) {
     // #145 (D19-16): Explain config vs .customize.yaml distinction
     info(
@@ -363,6 +364,7 @@ export async function configCommand(): Promise<void> {
     const contentRoot = findPackageRoot(__dirname);
     const agentsDir = join(rootDir, AGENTS_DIR);
     const index = await buildContentIndex(contentRoot);
+    const previousContent = manifest.content;
     const { projectType, teamSize } = manifest.content;
 
     // --- Content preset selection (mirrors init flow) ---
@@ -478,6 +480,10 @@ export async function configCommand(): Promise<void> {
 
     // Update manifest content wholesale
     manifest.content = newSelection;
+    contentMetadataChanged =
+      previousContent.preset !== newSelection.preset ||
+      previousContent.projectType !== newSelection.projectType ||
+      previousContent.teamSize !== newSelection.teamSize;
 
     // Regenerate canonical and root AGENTS.md after content changes
     if (contentChanges.added.length > 0 || contentChanges.removed.length > 0) {
@@ -495,7 +501,7 @@ export async function configCommand(): Promise<void> {
   diff.addedContent = contentChanges.added;
   diff.removedContent = contentChanges.removed;
 
-  if (isDiffEmpty(diff) && defaultBranch === currentBranch) {
+  if (isDiffEmpty(diff) && defaultBranch === currentBranch && !contentMetadataChanged) {
     console.log();
     info("No changes detected.");
     console.log();

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -376,7 +376,7 @@ export async function configCommand(): Promise<void> {
         message: "Select content profile:",
         choices: PRESETS.map((p) => {
           const excluded = countPresetExclusions(p, index);
-          const estimated = p.id !== "custom" ? estimatePresetItemCount(p, projectType, teamSize, index) : 0;
+          const estimated = p.id !== "custom" ? estimatePresetItemCount(p, projectType, teamSize, index, undefined, { skipContextFilters: true }) : 0;
           const countHint = estimated > 0 ? ` (~${estimated} items)` : "";
           const suffix = excluded > 0 ? ` (excludes ${excluded} of ${totalItems})` : "";
           return {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -45,7 +45,12 @@ import {
   extractContentReferences,
   validateOrchestrationDependencies,
   TYPE_TO_SELECTION_KEY,
+  resolveSelection,
+  countPresetExclusions,
+  estimatePresetItemCount,
+  getAllContentIds,
 } from "../../content/index.js";
+import { PRESETS, getPreset, type PresetId } from "../../content/presets.js";
 import { generateCanonicalAgentsMd, generateRootAgentsMd } from "../shared/agentsContent.js";
 import { safeWriteFile } from "../../merge/safeWrite.js";
 import { generateWorktreeInclude, extractManagedContent } from "../../worktree/index.js";
@@ -347,153 +352,164 @@ export async function configCommand(): Promise<void> {
   // --- Content management ---
   const contentChanges: { added: Array<{ type: string; id: string }>; removed: Array<{ type: string; id: string }> } = { added: [], removed: [] };
   if (manifest.content) {
-    const manageContent = await inquirer.prompt<{ manage: boolean }>([
+    // #145 (D19-16): Explain config vs .customize.yaml distinction
+    info(
+      chalk.dim("Config adds/removes content items. To customize an item's behavior without ") +
+      chalk.dim("removing it, use .hatch3r/<type>/<id>.customize.yaml instead."),
+    );
+    console.log();
+
+    const contentRoot = findPackageRoot(__dirname);
+    const agentsDir = join(rootDir, AGENTS_DIR);
+    const index = await buildContentIndex(contentRoot);
+    const { projectType, teamSize } = manifest.content;
+
+    // --- Content preset selection (mirrors init flow) ---
+    const totalItems = index.items.length;
+    const presetAnswer = await inquirer.prompt<{ preset: PresetId }>([
       {
-        type: "confirm",
-        name: "manage",
-        message: "Manage content items?",
-        default: false,
+        type: "select",
+        name: "preset",
+        message: "Select content profile:",
+        choices: PRESETS.map((p) => {
+          const excluded = countPresetExclusions(p, index);
+          const estimated = p.id !== "custom" ? estimatePresetItemCount(p, projectType, teamSize, index) : 0;
+          const countHint = estimated > 0 ? ` (~${estimated} items)` : "";
+          const suffix = excluded > 0 ? ` (excludes ${excluded} of ${totalItems})` : "";
+          return {
+            name: `${p.name} — ${p.description}${countHint}${suffix}`,
+            value: p.id,
+          };
+        }),
+        default: manifest.content.preset as PresetId,
       },
     ]);
+    const selectedPreset = getPreset(presetAnswer.preset);
 
-    if (manageContent.manage) {
-      // #145 (D19-16): Explain config vs .customize.yaml distinction
-      info(
-        chalk.dim("Config adds/removes content items. To customize an item's behavior without ") +
-        chalk.dim("removing it, use .hatch3r/<type>/<id>.customize.yaml instead."),
-      );
-      console.log();
-
-      const contentRoot = findPackageRoot(__dirname);
-      const agentsDir = join(rootDir, AGENTS_DIR);
-      const index = await buildContentIndex(contentRoot);
-
-      // Build current installed set from manifest
-      const currentIds = new Set<string>();
-      for (const ids of Object.values(manifest.content.items)) {
-        for (const id of ids) currentIds.add(id);
+    // --- Custom content selection (tag-grouped, mirrors init flow) ---
+    let customSelections: string[] | undefined;
+    if (selectedPreset.id === "custom") {
+      const currentIds = getAllContentIds(manifest.content);
+      const tagGroups = new Map<string, typeof index.items>();
+      for (const item of index.items) {
+        const primaryTag = item.tags[0] ?? "other";
+        if (!tagGroups.has(primaryTag)) tagGroups.set(primaryTag, []);
+        tagGroups.get(primaryTag)!.push(item);
       }
 
-      const contentAnswer = await inquirer.prompt<{ items: string[] }>([
-        {
-          type: "checkbox",
-          name: "items",
-          message: "Select content items (space to toggle):",
-          choices: index.items.map((item) => ({
+      const TAG_LABELS: Record<string, string> = {
+        core: "Core", planning: "Planning", implementation: "Implementation",
+        review: "Review", devops: "DevOps", maintenance: "Maintenance",
+        greenfield: "Greenfield", brownfield: "Brownfield", board: "Board",
+        security: "Security", a11y: "Accessibility", performance: "Performance",
+        customize: "Customization", other: "Other",
+      };
+      const groupedChoices: Array<InstanceType<typeof inquirer.Separator> | { name: string; value: string; checked: boolean }> = [];
+      for (const [tag, items] of tagGroups) {
+        groupedChoices.push(new inquirer.Separator(`── ${TAG_LABELS[tag] ?? tag} (${items.length}) ──`));
+        for (const item of items) {
+          groupedChoices.push({
             name: `${item.type}: ${item.id.replace(/^(cmd-)?hatch3r-/, "")} — ${item.description.slice(0, 60)}`,
             value: item.id,
             checked: currentIds.has(item.id),
-          })),
+          });
+        }
+      }
+
+      const customAnswer = await inquirer.prompt<{ items: string[] }>([
+        {
+          type: "checkbox",
+          name: "items",
+          message: "Select content items:",
+          choices: groupedChoices,
           ...(wslTheme && { theme: wslTheme }),
         },
       ]);
+      customSelections = customAnswer.items;
+    }
 
-      const newIds = new Set(contentAnswer.items);
+    // --- Resolve new selection and diff against current ---
+    const newSelection = resolveSelection(selectedPreset, projectType, teamSize, index, customSelections);
+    const oldIds = getAllContentIds(manifest.content);
+    const newIds = getAllContentIds(newSelection);
 
-      // Identify removed items and warn about dependents (D19-6)
-      const pendingRemovals: string[] = [];
-      for (const id of currentIds) {
-        if (!newIds.has(id)) pendingRemovals.push(id);
-      }
+    // Identify removed items and warn about dependents (D19-6)
+    const pendingRemovals: string[] = [];
+    for (const id of oldIds) {
+      if (!newIds.has(id)) pendingRemovals.push(id);
+    }
 
-      if (pendingRemovals.length > 0) {
-        const dependencyWarnings: string[] = [];
-        for (const removedId of pendingRemovals) {
-          const dependents: string[] = [];
-          for (const keepId of contentAnswer.items) {
-            const keepItem = index.byId.get(keepId);
-            if (!keepItem) continue;
-            try {
-              const filePath = keepItem.type === "skill"
-                ? join(agentsDir, keepItem.relativePath, "SKILL.md")
-                : join(agentsDir, keepItem.relativePath);
-              const content = await readFile(filePath, "utf-8");
-              const refs = extractContentReferences(content);
-              if (refs.includes(removedId)) {
-                dependents.push(keepId);
-              }
-            } catch {
-              // File not readable, skip
+    if (pendingRemovals.length > 0) {
+      const dependencyWarnings: string[] = [];
+      for (const removedId of pendingRemovals) {
+        const dependents: string[] = [];
+        for (const keepId of newIds) {
+          const keepItem = index.byId.get(keepId);
+          if (!keepItem) continue;
+          try {
+            const filePath = keepItem.type === "skill"
+              ? join(agentsDir, keepItem.relativePath, "SKILL.md")
+              : join(agentsDir, keepItem.relativePath);
+            const content = await readFile(filePath, "utf-8");
+            const refs = extractContentReferences(content);
+            if (refs.includes(removedId)) {
+              dependents.push(keepId);
             }
-          }
-          if (dependents.length > 0) {
-            dependencyWarnings.push(
-              `Removing "${removedId}" — referenced by: ${dependents.join(", ")}`,
-            );
+          } catch {
+            // File not readable, skip
           }
         }
-
-        // Check orchestration dependencies with the proposed new selection
-        const proposedSelection: ContentSelection = {
-          ...manifest.content!,
-          items: {
-            agents: [], skills: [], rules: [], commands: [],
-            prompts: [], hooks: [], githubAgents: [],
-          },
-        };
-        for (const id of contentAnswer.items) {
-          const proposedItem = index.byId.get(id);
-          if (proposedItem) {
-            const key = TYPE_TO_SELECTION_KEY[proposedItem.type];
-            if (key) proposedSelection.items[key].push(proposedItem.id);
-          }
-        }
-        const orchWarnings = validateOrchestrationDependencies(proposedSelection);
-        dependencyWarnings.push(...orchWarnings);
-
-        if (dependencyWarnings.length > 0) {
-          console.log();
-          warn("Dependency warnings for removed content:");
-          for (const w of dependencyWarnings) {
-            console.log(chalk.dim(`  ${w}`));
-          }
-          console.log();
+        if (dependents.length > 0) {
+          dependencyWarnings.push(
+            `Removing "${removedId}" — referenced by: ${dependents.join(", ")}`,
+          );
         }
       }
 
-      // Find added and removed items
-      for (const id of contentAnswer.items) {
-        if (!currentIds.has(id)) {
-          const item = index.byId.get(id);
-          if (item) {
-            contentChanges.added.push({ type: item.type, id: item.id });
-            await addContentItem(contentRoot, agentsDir, item);
-          }
-        }
-      }
-      for (const id of currentIds) {
-        if (!newIds.has(id)) {
-          const item = index.byId.get(id);
-          if (item) {
-            contentChanges.removed.push({ type: item.type, id: item.id });
-            await removeContentItem(agentsDir, item, { rootDir });
-          }
-        }
-      }
+      const orchWarnings = validateOrchestrationDependencies(newSelection);
+      dependencyWarnings.push(...orchWarnings);
 
-      // Update manifest content items
-      const newItems: ContentSelection["items"] = {
-        agents: [], skills: [], rules: [], commands: [],
-        prompts: [], hooks: [], githubAgents: [],
-      };
-      for (const id of contentAnswer.items) {
+      if (dependencyWarnings.length > 0) {
+        console.log();
+        warn("Dependency warnings for removed content:");
+        for (const w of dependencyWarnings) {
+          console.log(chalk.dim(`  ${w}`));
+        }
+        console.log();
+      }
+    }
+
+    // Apply adds and removes
+    for (const id of newIds) {
+      if (!oldIds.has(id)) {
         const item = index.byId.get(id);
         if (item) {
-          const key = TYPE_TO_SELECTION_KEY[item.type];
-          if (key) newItems[key].push(item.id);
+          contentChanges.added.push({ type: item.type, id: item.id });
+          await addContentItem(contentRoot, agentsDir, item);
         }
       }
-      manifest.content.items = newItems;
-
-      // Regenerate canonical and root AGENTS.md after content changes
-      if (contentChanges.added.length > 0 || contentChanges.removed.length > 0) {
-        const canonicalAgentsMd = await generateCanonicalAgentsMd(agentsDir);
-        await safeWriteFile(join(agentsDir, "AGENTS.md"), canonicalAgentsMd);
-        const rootAgentsMd = await generateRootAgentsMd(agentsDir);
-        await safeWriteFile(join(rootDir, "AGENTS.md"), rootAgentsMd.full, {
-          managedContent: rootAgentsMd.inner,
-        });
+    }
+    for (const id of oldIds) {
+      if (!newIds.has(id)) {
+        const item = index.byId.get(id);
+        if (item) {
+          contentChanges.removed.push({ type: item.type, id: item.id });
+          await removeContentItem(agentsDir, item, { rootDir });
+        }
       }
+    }
+
+    // Update manifest content wholesale
+    manifest.content = newSelection;
+
+    // Regenerate canonical and root AGENTS.md after content changes
+    if (contentChanges.added.length > 0 || contentChanges.removed.length > 0) {
+      const canonicalAgentsMd = await generateCanonicalAgentsMd(agentsDir);
+      await safeWriteFile(join(agentsDir, "AGENTS.md"), canonicalAgentsMd);
+      const rootAgentsMd = await generateRootAgentsMd(agentsDir);
+      await safeWriteFile(join(rootDir, "AGENTS.md"), rootAgentsMd.full, {
+        managedContent: rootAgentsMd.inner,
+      });
     }
   }
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -35,6 +35,7 @@ import { detectSubRepos, detectWorkspaceContext } from "../../workspace/detect.j
 import { syncWorkspaceRepos } from "../../workspace/sync.js";
 import { detectRepoGitIdentity } from "../../workspace/git.js";
 import { TOOL_DISPLAY_NAMES, TOOL_PROMPT_CHOICES, FEATURE_CHOICES, MCP_CHOICES, PLATFORM_DISPLAY_NAMES, PLATFORM_MCP_SERVER, sanitizeInput, isWSL } from "../shared/constants.js";
+import { buildTagGroupedCustomContentChoices } from "../shared/customContentChoices.js";
 import {
   buildContentIndex,
   getAvailableItems,
@@ -390,31 +391,7 @@ export async function configCommand(): Promise<void> {
     let customSelections: string[] | undefined;
     if (selectedPreset.id === "custom") {
       const currentIds = getAllContentIds(manifest.content);
-      const tagGroups = new Map<string, typeof index.items>();
-      for (const item of index.items) {
-        const primaryTag = item.tags[0] ?? "other";
-        if (!tagGroups.has(primaryTag)) tagGroups.set(primaryTag, []);
-        tagGroups.get(primaryTag)!.push(item);
-      }
-
-      const TAG_LABELS: Record<string, string> = {
-        core: "Core", planning: "Planning", implementation: "Implementation",
-        review: "Review", devops: "DevOps", maintenance: "Maintenance",
-        greenfield: "Greenfield", brownfield: "Brownfield", board: "Board",
-        security: "Security", a11y: "Accessibility", performance: "Performance",
-        customize: "Customization", other: "Other",
-      };
-      const groupedChoices: Array<InstanceType<typeof inquirer.Separator> | { name: string; value: string; checked: boolean }> = [];
-      for (const [tag, items] of tagGroups) {
-        groupedChoices.push(new inquirer.Separator(`── ${TAG_LABELS[tag] ?? tag} (${items.length}) ──`));
-        for (const item of items) {
-          groupedChoices.push({
-            name: `${item.type}: ${item.id.replace(/^(cmd-)?hatch3r-/, "")} — ${item.description.slice(0, 60)}`,
-            value: item.id,
-            checked: currentIds.has(item.id),
-          });
-        }
-      }
+      const groupedChoices = buildTagGroupedCustomContentChoices(index.items, (item) => currentIds.has(item.id));
 
       const customAnswer = await inquirer.prompt<{ items: string[] }>([
         {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -408,7 +408,7 @@ export async function configCommand(): Promise<void> {
     }
 
     // --- Resolve new selection and diff against current ---
-    const newSelection = resolveSelection(selectedPreset, projectType, teamSize, index, customSelections);
+    const newSelection = resolveSelection(selectedPreset, projectType, teamSize, index, customSelections, undefined, { skipContextFilters: true });
     const oldIds = getAllContentIds(manifest.content);
     const newIds = getAllContentIds(newSelection);
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -39,6 +39,7 @@ import {
   warn,
 } from "../shared/ui.js";
 import { findPackageRoot } from "../shared/paths.js";
+import { buildTagGroupedCustomContentChoices } from "../shared/customContentChoices.js";
 import { TOOL_DISPLAY_NAMES, TOOL_PROMPT_CHOICES, FEATURE_CHOICES, MCP_CHOICES, PLATFORM_DISPLAY_NAMES, PLATFORM_MCP_SERVER, sanitizeInput, isWSL, formatCommandHint, TOOL_SECRET_NOTES } from "../shared/constants.js";
 import { generateIntegrityManifest, writeIntegrityManifest } from "../../integrity/index.js";
 import { HATCH3R_VERSION } from "../../version.js";
@@ -614,32 +615,10 @@ export async function initCommand(
   let customSelections: string[] | undefined;
   if (selectedPreset.id === "custom") {
     const contentIndex = filterIndex;
-    const tagGroups = new Map<string, typeof contentIndex.items>();
-    for (const item of contentIndex.items) {
-      const primaryTag = item.tags[0] ?? "other";
-      if (!tagGroups.has(primaryTag)) tagGroups.set(primaryTag, []);
-      tagGroups.get(primaryTag)!.push(item);
-    }
-
-    // Build grouped choices with separators
-    const TAG_LABELS: Record<string, string> = {
-      core: "Core", planning: "Planning", implementation: "Implementation",
-      review: "Review", devops: "DevOps", maintenance: "Maintenance",
-      greenfield: "Greenfield", brownfield: "Brownfield", board: "Board",
-      security: "Security", a11y: "Accessibility", performance: "Performance",
-      customize: "Customization", other: "Other",
-    };
-    const groupedChoices: Array<InstanceType<typeof inquirer.Separator> | { name: string; value: string; checked: boolean }> = [];
-    for (const [tag, items] of tagGroups) {
-      groupedChoices.push(new inquirer.Separator(`── ${TAG_LABELS[tag] ?? tag} (${items.length}) ──`));
-      for (const item of items) {
-        groupedChoices.push({
-          name: `${item.type}: ${item.id.replace(/^(cmd-)?hatch3r-/, "")} — ${item.description.slice(0, 60)}`,
-          value: item.id,
-          checked: item.protected || item.tags.includes("core"),
-        });
-      }
-    }
+    const groupedChoices = buildTagGroupedCustomContentChoices(
+      contentIndex.items,
+      (item) => item.protected || item.tags.includes("core"),
+    );
 
     const customAnswer = await inquirer.prompt<{ items: string[] }>([
       {
@@ -906,31 +885,10 @@ async function runWorkspaceInit(
     let customSelections: string[] | undefined;
     if (selectedPreset.id === "custom") {
       const contentIndex = wsFilterIndex;
-      const wsTagGroups = new Map<string, typeof contentIndex.items>();
-      for (const item of contentIndex.items) {
-        const primaryTag = item.tags[0] ?? "other";
-        if (!wsTagGroups.has(primaryTag)) wsTagGroups.set(primaryTag, []);
-        wsTagGroups.get(primaryTag)!.push(item);
-      }
-
-      const WS_TAG_LABELS: Record<string, string> = {
-        core: "Core", planning: "Planning", implementation: "Implementation",
-        review: "Review", devops: "DevOps", maintenance: "Maintenance",
-        greenfield: "Greenfield", brownfield: "Brownfield", board: "Board",
-        security: "Security", a11y: "Accessibility", performance: "Performance",
-        customize: "Customization", other: "Other",
-      };
-      const wsGroupedChoices: Array<InstanceType<typeof inquirer.Separator> | { name: string; value: string; checked: boolean }> = [];
-      for (const [tag, items] of wsTagGroups) {
-        wsGroupedChoices.push(new inquirer.Separator(`── ${WS_TAG_LABELS[tag] ?? tag} (${items.length}) ──`));
-        for (const item of items) {
-          wsGroupedChoices.push({
-            name: `${item.type}: ${item.id.replace(/^(cmd-)?hatch3r-/, "")} — ${item.description.slice(0, 60)}`,
-            value: item.id,
-            checked: item.protected || item.tags.includes("core"),
-          });
-        }
-      }
+      const wsGroupedChoices = buildTagGroupedCustomContentChoices(
+        contentIndex.items,
+        (item) => item.protected || item.tags.includes("core"),
+      );
 
       const customAnswer = await inquirer.prompt<{ items: string[] }>([
         {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -53,7 +53,7 @@ import { parseGitRemote, parseGitDefaultBranch, getGitRemoteUrl, detectPlatformF
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONTENT_ROOT = findPackageRoot(__dirname);
 
-const DEFAULT_TOOLS: Tool[] = ["cursor"];
+const DEFAULT_TOOLS: Tool[] = ["claude"];
 const DEFAULT_FEATURE_KEYS = Object.keys(DEFAULT_FEATURES) as (keyof Features)[];
 const DEFAULT_MCP: string[] = ["playwright", "github", "context7"];
 
@@ -460,7 +460,7 @@ export async function initCommand(
       repoInfo.languages[0] === "unknown" &&
       repoInfo.existingTools.length === 0 &&
       !repoInfo.hasExistingAgents;
-    const presetId = validateFlag(opts.preset, ["minimal", "standard", "full"], "standard", "preset");
+    const presetId = validateFlag(opts.preset, ["minimal", "standard", "full"], "full", "preset");
     const projectType = validateFlag(opts.projectType, ["greenfield", "brownfield"], isGreenfield ? "greenfield" : "brownfield", "project-type");
     const teamSize = validateFlag(opts.teamSize, ["solo", "team"], "solo", "team-size");
     const preset = getPreset(presetId);
@@ -600,7 +600,7 @@ export async function initCommand(
           value: p.id,
         };
       }),
-      default: "standard" as PresetId,
+      default: "full" as PresetId,
     },
   ]);
   const selectedPreset = getPreset(presetAnswer.preset);
@@ -752,7 +752,7 @@ async function runWorkspaceInit(
       ? Array.from(new Set([platformMcp, ...DEFAULT_MCP.filter((s) => s !== "github")]))
       : [];
     const index = await buildContentIndex(CONTENT_ROOT);
-    const contentSelection = resolveSelection(getPreset("standard"), "brownfield", "solo", index);
+    const contentSelection = resolveSelection(getPreset("full"), "brownfield", "solo", index);
     const wsManifest = createWorkspaceManifest(
       basename(rootDir) || "workspace",
       { platform, tools, features, mcp: { servers: mcpServers }, content: contentSelection },
@@ -832,7 +832,7 @@ async function runWorkspaceInit(
       repoInfo.languages[0] === "unknown" &&
       repoInfo.existingTools.length === 0 &&
       !repoInfo.hasExistingAgents;
-    const presetId = validateFlag(opts.preset, ["minimal", "standard", "full"], "standard", "preset");
+    const presetId = validateFlag(opts.preset, ["minimal", "standard", "full"], "full", "preset");
     const projectType = validateFlag(opts.projectType, ["greenfield", "brownfield"], isGreenfield ? "greenfield" : "brownfield", "project-type");
     const teamSize = validateFlag(opts.teamSize, ["solo", "team"], "solo", "team-size");
     const preset = getPreset(presetId);
@@ -897,7 +897,7 @@ async function runWorkspaceInit(
             value: p.id,
           };
         }),
-        default: "standard" as PresetId,
+        default: "full" as PresetId,
       },
     ]);
     const selectedPreset = getPreset(presetAnswer.preset);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -33,7 +33,7 @@ program
     `Comma-separated tools (${TOOL_CHOICES})`,
   )
   .option("--yes", "Skip interactive prompts, use defaults")
-  .option("--preset <preset>", "Content preset: minimal, standard, full (default: standard)")
+  .option("--preset <preset>", "Content preset: minimal, standard, full (default: full)")
   .option("--project-type <type>", "Project type: greenfield, brownfield")
   .option("--team-size <size>", "Team size: solo, team")
   .option("--workspace", "Initialize as a multi-repo workspace")

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -49,7 +49,7 @@ export function createProgram(): Command {
       `Comma-separated tools (${TOOL_CHOICES})`,
     )
     .option("--yes", "Skip interactive prompts, use defaults")
-    .option("--preset <preset>", "Content preset: minimal, standard, full (default: standard)")
+    .option("--preset <preset>", "Content preset: minimal, standard, full (default: full)")
     .option("--project-type <type>", "Project type: greenfield, brownfield")
     .option("--team-size <size>", "Team size: solo, team")
     .option("--workspace", "Initialize as a multi-repo workspace")

--- a/src/cli/shared/customContentChoices.ts
+++ b/src/cli/shared/customContentChoices.ts
@@ -1,0 +1,54 @@
+import inquirer from "inquirer";
+import type { CatalogItem } from "../../content/index.js";
+
+/** Display labels for primary content tags (custom profile checkbox groups). */
+export const CONTENT_TAG_LABELS: Record<string, string> = {
+  core: "Core",
+  planning: "Planning",
+  implementation: "Implementation",
+  review: "Review",
+  devops: "DevOps",
+  maintenance: "Maintenance",
+  greenfield: "Greenfield",
+  brownfield: "Brownfield",
+  board: "Board",
+  security: "Security",
+  a11y: "Accessibility",
+  performance: "Performance",
+  customize: "Customization",
+  other: "Other",
+};
+
+export type TagGroupedCustomContentChoice =
+  | InstanceType<typeof inquirer.Separator>
+  | { name: string; value: string; checked: boolean };
+
+/**
+ * Build inquirer checkbox choices grouped by each item's primary tag (init/config custom preset).
+ */
+export function buildTagGroupedCustomContentChoices(
+  items: CatalogItem[],
+  isChecked: (item: CatalogItem) => boolean,
+): TagGroupedCustomContentChoice[] {
+  const tagGroups = new Map<string, CatalogItem[]>();
+  for (const item of items) {
+    const primaryTag = item.tags[0] ?? "other";
+    if (!tagGroups.has(primaryTag)) tagGroups.set(primaryTag, []);
+    tagGroups.get(primaryTag)!.push(item);
+  }
+
+  const groupedChoices: TagGroupedCustomContentChoice[] = [];
+  for (const [tag, groupItems] of tagGroups) {
+    groupedChoices.push(
+      new inquirer.Separator(`── ${CONTENT_TAG_LABELS[tag] ?? tag} (${groupItems.length}) ──`),
+    );
+    for (const item of groupItems) {
+      groupedChoices.push({
+        name: `${item.type}: ${item.id.replace(/^(cmd-)?hatch3r-/, "")} — ${item.description.slice(0, 60)}`,
+        value: item.id,
+        checked: isChecked(item),
+      });
+    }
+  }
+  return groupedChoices;
+}

--- a/src/cli/shared/customContentChoices.ts
+++ b/src/cli/shared/customContentChoices.ts
@@ -2,7 +2,7 @@ import inquirer from "inquirer";
 import type { CatalogItem } from "../../content/index.js";
 
 /** Display labels for primary content tags (custom profile checkbox groups). */
-export const CONTENT_TAG_LABELS: Record<string, string> = {
+const CONTENT_TAG_LABELS: Record<string, string> = {
   core: "Core",
   planning: "Planning",
   implementation: "Implementation",
@@ -19,7 +19,7 @@ export const CONTENT_TAG_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-export type TagGroupedCustomContentChoice =
+type TagGroupedCustomContentChoice =
   | InstanceType<typeof inquirer.Separator>
   | { name: string; value: string; checked: boolean };
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -368,6 +368,7 @@ export function resolveSelection(
   index: ContentIndex,
   customSelections?: string[],
   projectLanguages?: string[],
+  options?: { skipContextFilters?: boolean },
 ): ContentSelection {
   let selected: CatalogItem[];
 
@@ -413,43 +414,47 @@ export function resolveSelection(
       );
     }
 
-    // Context filtering: project type
-    if (projectType === "greenfield") {
-      // Remove items tagged ONLY with "brownfield"
-      selected = selected.filter(
-        (item) =>
-          item.protected ||
-          !item.tags.includes("brownfield") ||
-          item.tags.some((t) => t !== "brownfield" && t !== "team" && t !== "solo"),
-      );
-    } else {
-      // Remove items tagged ONLY with "greenfield"
-      selected = selected.filter(
-        (item) =>
-          item.protected ||
-          !item.tags.includes("greenfield") ||
-          item.tags.some((t) => t !== "greenfield" && t !== "team" && t !== "solo"),
-      );
-    }
-
-    // Context filtering: team size
-    if (teamSize === "solo") {
-      // Remove items whose tags are exclusively team/board (no other workflow/domain tags)
-      selected = selected.filter((item) => {
-        if (item.protected) return true;
-        if (!item.tags.includes("team") && !item.tags.includes("board")) return true;
-        // Has team/board tag — keep if it has other non-context tags too
-        return item.tags.some(
-          (t) => t !== "team" && t !== "board" && t !== "solo" && t !== "greenfield" && t !== "brownfield",
+    // Context filtering: project type, team size, language
+    // Skipped when called from config — the user is explicitly choosing a preset
+    // and should not have items silently removed by stored context filters.
+    if (!options?.skipContextFilters) {
+      if (projectType === "greenfield") {
+        // Remove items tagged ONLY with "brownfield"
+        selected = selected.filter(
+          (item) =>
+            item.protected ||
+            !item.tags.includes("brownfield") ||
+            item.tags.some((t) => t !== "brownfield" && t !== "team" && t !== "solo"),
         );
-      });
+      } else {
+        // Remove items tagged ONLY with "greenfield"
+        selected = selected.filter(
+          (item) =>
+            item.protected ||
+            !item.tags.includes("greenfield") ||
+            item.tags.some((t) => t !== "greenfield" && t !== "team" && t !== "solo"),
+        );
+      }
+
+      // Context filtering: team size
+      if (teamSize === "solo") {
+        // Remove items whose tags are exclusively team/board (no other workflow/domain tags)
+        selected = selected.filter((item) => {
+          if (item.protected) return true;
+          if (!item.tags.includes("team") && !item.tags.includes("board")) return true;
+          // Has team/board tag — keep if it has other non-context tags too
+          return item.tags.some(
+            (t) => t !== "team" && t !== "board" && t !== "solo" && t !== "greenfield" && t !== "brownfield",
+          );
+        });
+      }
     }
   }
 
   // Language filtering (Finding #71): remove items whose language tags
   // don't match the detected project languages. Items without any language
   // tags pass through (language-agnostic content).
-  if (projectLanguages && projectLanguages.length > 0) {
+  if (!options?.skipContextFilters && projectLanguages && projectLanguages.length > 0) {
     selected = selected.filter((item) => {
       if (item.protected) return true;
       const itemLangTags = item.tags.filter(isLanguageTag);

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -893,8 +893,9 @@ export function estimatePresetItemCount(
   teamSize: "solo" | "team",
   index: ContentIndex,
   projectLanguages?: string[],
+  options?: { skipContextFilters?: boolean },
 ): number {
-  const selection = resolveSelection(preset, projectType, teamSize, index, undefined, projectLanguages);
+  const selection = resolveSelection(preset, projectType, teamSize, index, undefined, projectLanguages, options);
   return Object.values(selection.items).reduce((sum, arr) => sum + arr.length, 0);
 }
 

--- a/src/content/presets.ts
+++ b/src/content/presets.ts
@@ -20,14 +20,14 @@ export const PRESETS: ContentPreset[] = [
   },
   {
     id: "standard",
-    name: "Standard (recommended)",
+    name: "Standard",
     description: "Full development lifecycle without niche audits",
     includeTags: ["core", "planning", "implementation", "review", "devops", "maintenance"],
     excludeTags: ["board", "a11y", "performance", "customize"],
   },
   {
     id: "full",
-    name: "Full",
+    name: "Full (recommended)",
     description: "Everything including board management and all audits",
     includeTags: [], // empty = include all
     excludeTags: [],

--- a/website/docs/guides/customization.md
+++ b/website/docs/guides/customization.md
@@ -91,4 +91,4 @@ Hooks trigger agents on specific lifecycle events (e.g., post-commit, pre-push, 
 
 ## Presets
 
-hatch3r ships with 4 content presets: **Minimal** (core only), **Standard** (recommended, full dev lifecycle), **Full** (everything), and **Custom** (pick exactly what you need). Select during `hatch3r init` or change later with `hatch3r config`.
+hatch3r ships with 4 content presets: **Minimal** (core only), **Standard** (full dev lifecycle), **Full** (recommended, everything), and **Custom** (pick exactly what you need). Select during `hatch3r init` or change later with `hatch3r config`.

--- a/website/docs/reference/architecture/content-model.md
+++ b/website/docs/reference/architecture/content-model.md
@@ -57,7 +57,7 @@ The `hatch.json` manifest includes a `content` field that tracks which items are
 ```json
 {
   "content": {
-    "preset": "standard",
+    "preset": "full",
     "projectType": "brownfield",
     "teamSize": "solo",
     "items": {

--- a/website/docs/reference/commands/cli-commands.md
+++ b/website/docs/reference/commands/cli-commands.md
@@ -24,7 +24,7 @@ npx hatch3r init --preset full --project-type brownfield --team-size team --yes
 |------|--------|---------|-------------|
 | `--tools` | comma-separated tool names | auto-detected | Which coding tools to configure |
 | `--yes` | — | off | Skip all prompts (headless mode) |
-| `--preset` | `minimal`, `standard`, `full` | `standard` | Content profile preset |
+| `--preset` | `minimal`, `standard`, `full` | `full` | Content profile preset |
 | `--project-type` | `greenfield`, `brownfield` | auto-detected | Project type context |
 | `--team-size` | `solo`, `team` | `solo` | Team size context |
 | `--workspace` | — | off | Force workspace mode for multi-repo directories |

--- a/website/docs/reference/configuration.md
+++ b/website/docs/reference/configuration.md
@@ -128,7 +128,7 @@ The `content` field tracks which content items are installed. It is populated du
 ```json
 {
   "content": {
-    "preset": "standard",
+    "preset": "full",
     "projectType": "brownfield",
     "teamSize": "solo",
     "items": {
@@ -168,7 +168,7 @@ When `hatch3r init --workspace` is run in a directory containing multiple git re
     "tools": ["cursor", "claude"],
     "features": { "agents": true, "skills": true, "rules": true, "...": true },
     "mcp": { "servers": ["github", "playwright"] },
-    "content": { "preset": "standard", "projectType": "brownfield", "teamSize": "team", "items": { "...": [] } }
+    "content": { "preset": "full", "projectType": "brownfield", "teamSize": "team", "items": { "...": [] } }
   },
   "repos": [
     {


### PR DESCRIPTION
## Summary

- **Config content flow**: Replaced "Manage content items?" confirm prompt with direct preset selection (minimal/standard/full/custom) and tag-grouped custom picker, matching the `hatch3r init` experience
- **Default content profile**: Changed default from "Standard" to "Full (recommended)" for both interactive and headless (`--yes`) init
- **Default tool fallback**: Changed fallback tool from Cursor to Claude Code when auto-detection finds no existing tools

## Changed files

| Area | Files |
|------|-------|
| Source | `config.ts`, `init.ts`, `presets.ts`, `program.ts`, `index.ts` |
| Tests | `config.test.ts`, `init.test.ts`, `lifecycle.test.ts`, `update.test.ts`, `migration-checkpoints.test.ts`, `hatchJson.test.ts` |
| Docs | `cli-commands.md`, `configuration.md`, `content-model.md`, `customization.md` |
| Release | `package.json` (1.5.1), `CHANGELOG.md`, `adapter-capability-matrix.md` |

## Test plan

- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm test` — 1993/1993 tests pass
- [x] `npm run lint` — 0 errors
- [ ] Manual: `npx hatch3r init --yes` in fresh dir → uses "full" preset, "claude" tool
- [ ] Manual: `npx hatch3r config` in initialized dir → goes directly to preset selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes interactive/headless init defaults and the `hatch3r config` content-selection flow, which can add/remove managed files and regenerate `AGENTS.md` based on preset resolution.
> 
> **Overview**
> **Content management UX is reworked.** `hatch3r config` now skips the "Manage content items?" confirm and instead always prompts for a content preset (`minimal`/`standard`/`full`/`custom`), with a tag-grouped custom picker; it resolves the resulting selection, applies add/remove diffs, and treats preset metadata-only changes as real updates.
> 
> **Defaults shift toward more content.** Init now defaults to the **Full (recommended)** preset (including `--yes`) and the fallback tool switches from `cursor` to `claude`; preset naming is updated to mark Full as recommended.
> 
> **Supporting refactors/docs.** Custom preset checkbox grouping is extracted into `buildTagGroupedCustomContentChoices`, selection resolution adds `skipContextFilters` for config-driven preset choices, docs/tests are updated for the new defaults, version is bumped to `1.5.1`, and revision command docs are modularized with new `commands/revision/*` files plus a new `governance/EVOLVE.md` prompt and gitignored `governance/EVOLVE-REPORT.md` artifact.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bba2826f542688be3637fbdcc4a6cb285218956a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->