### PR TITLE
release: v1.6.2 — hide companion content from tool command/agent pickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [1.6.2] - 2026-04-22
+
+### Fixed
+
+- **Companion content no longer clutters the tool command/agent picker**: `hatch3r init` / `hatch3r sync` previously emitted every `.md` file under `commands/` and `agents/` as a user-invocable entry in each tool's picker — including ~40 companion files (5 `type: shared-context`, 20 `agents/modes/*` with `type: mode`, 4 `agents/shared/*` with `type: reference`, 11 sub-workflow files under `commands/board/pickup-*` and `commands/revision/*`) that exist only to be referenced by parent commands/agents, not invoked directly. The recursive `readGlobMd()` (`src/adapters/canonical.ts:460`) still reads the full tree so cross-references continue to resolve, but a new `filterUserFacing()` helper gates per-adapter emission on two signals: the file's path relative to its content-type baseDir must have no subdirectory separator, **and** its frontmatter `type:` must match the reader bucket (`command` / `agent`) or be absent. Applied to `processCommandsRaw` and a new `readUserFacingCanonicalFiles` wrapper in `src/adapters/base.ts`, plus direct call sites in `gemini.ts` and each of the 10 agent-emitting adapters (claude, cursor, copilot, opencode, codex, amazonq, goose, windsurf, cline, agentsmd). The `.agents/` canonical mirror in `src/content/index.ts` is unchanged, so parent commands that read shared context by name keep working.
+- **`parseFrontmatter` now surfaces the author-declared type separately from the parser default**: `parseFrontmatter()` returns an additional `rawType?: string` that is `undefined` when `type:` is absent from frontmatter, distinct from `metadata.type` which falls back to `"rule"`. `CanonicalFile.frontmatterType` is populated from `rawType`, letting the adapter filter distinguish "user chose `type: command`" from "parser defaulted to rule" — a distinction the previous shape could not express.
+
+### Tests
+
+- 7 new unit tests for `filterUserFacing` in `src/__tests__/adapters/canonical.test.ts` covering top-level pass, subdirectory drop, frontmatter-type whitelist, both-signals-AND for agents, legacy back-compat for files without frontmatter `type:`, safe default when `sourcePath` lies outside `baseDir`, and trailing-slash tolerance on `baseDir`.
+- 2 new adapter-level filter tests (claude, gemini) asserting that subdirectory fixtures (`pickup-fake`, `fake-mode`, `fake-reference`) and top-level `type: shared-context` fixture (`hatch3r-fake-shared`) are absent from `.claude/commands/`, `.claude/agents/`, and `.gemini/commands/` output while the primary `test-agent` / `test-command` fixtures survive.
+- 4 new fixture files under `src/__tests__/fixtures/agents/` (`agents/modes/fake-mode.md`, `agents/shared/fake-reference.md`, `commands/board/pickup-fake.md`, `commands/hatch3r-fake-shared.md`) exercise both filter signals.
+- 2 existing `readCanonicalFiles` tests adjusted to reflect the now-intentionally-larger fixture set (the raw reader sees all files; filtering happens at the emission layer). Test count 2,604 → 2,613.
+
 ## [1.6.1] - 2026-04-22
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatch3r",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatch3r",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatch3r",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Battle-tested agentic coding setup framework. One command to hatch your agent stack -- agents, skills, rules, commands, and MCP for every major AI coding tool.",
   "type": "module",
   "exports": {

--- a/src/__tests__/adapters/canonical.test.ts
+++ b/src/__tests__/adapters/canonical.test.ts
@@ -3,11 +3,13 @@ import { mkdtemp, mkdir, writeFile, rm, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  filterUserFacing,
   readCanonicalFiles,
   readCanonicalFilesDetailed,
   precedenceRank,
   sortByPrecedence,
 } from "../../adapters/canonical.js";
+import type { CanonicalFile } from "../../types.js";
 import { resolveTestPath } from "../fixtures.js";
 
 const FIXTURES_DIR = resolveTestPath(import.meta.url, "../fixtures/agents");
@@ -97,13 +99,18 @@ describe("readCanonicalFiles", () => {
   });
 
   describe("agents", () => {
-    it("should read agents from agents/ directory", async () => {
+    it("should read agents from agents/ directory (including subdirectories)", async () => {
       const results = await readCanonicalFiles(FIXTURES_DIR, "agents");
 
-      expect(results.length).toBe(2);
+      // The raw read is recursive by design so subdirectory companion
+      // content (modes, shared reference) remains readable by parent
+      // commands. Adapter filtering (`filterUserFacing`) happens later
+      // at the emission layer.
       const ids = results.map((r) => r.id);
       expect(ids).toContain("test-agent");
       expect(ids).toContain("readonly-agent");
+      expect(ids).toContain("fake-mode");
+      expect(ids).toContain("fake-reference");
       for (const r of results) {
         expect(r.type).toBe("agent");
       }
@@ -178,13 +185,20 @@ describe("readCanonicalFiles", () => {
   });
 
   describe("commands", () => {
-    it("should read commands from commands/ directory", async () => {
+    it("should read commands from commands/ directory (including subdirectories)", async () => {
       const results = await readCanonicalFiles(FIXTURES_DIR, "commands");
 
-      expect(results.length).toBe(1);
-      expect(results[0]!.id).toBe("test-command");
-      expect(results[0]!.type).toBe("command");
-      expect(results[0]!.description).toBe("A test command for unit testing");
+      // The raw read is recursive by design. The filter fixtures
+      // (`pickup-fake` in a subdir, `hatch3r-fake-shared` with type
+      // `shared-context`) appear here but are stripped by the per-adapter
+      // `filterUserFacing` step.
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain("test-command");
+      expect(ids).toContain("pickup-fake");
+      expect(ids).toContain("hatch3r-fake-shared");
+      const primary = results.find((r) => r.id === "test-command")!;
+      expect(primary.type).toBe("command");
+      expect(primary.description).toBe("A test command for unit testing");
     });
 
     it("should handle empty commands directory", async () => {
@@ -841,5 +855,87 @@ describe("parseFrontmatter precedence field", () => {
     const results = await readCanonicalFiles(tempDir, "rules");
     expect(results).toHaveLength(1);
     expect(results[0]!.precedence).toBeUndefined();
+  });
+});
+
+describe("filterUserFacing", () => {
+  const BASE = "/fake/agents/commands";
+
+  function makeFile(
+    overrides: Partial<CanonicalFile> & Pick<CanonicalFile, "id" | "sourcePath">,
+  ): CanonicalFile {
+    return {
+      type: "command",
+      description: "",
+      content: "",
+      rawContent: "",
+      ...overrides,
+    };
+  }
+
+  it("keeps top-level files whose frontmatter type matches the expected bucket", () => {
+    const files = [
+      makeFile({ id: "a", sourcePath: `${BASE}/hatch3r-a.md`, frontmatterType: "command" }),
+      makeFile({ id: "b", sourcePath: `${BASE}/hatch3r-b.md`, frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops files whose relative path contains a subdirectory separator", () => {
+    const files = [
+      makeFile({ id: "top", sourcePath: `${BASE}/hatch3r-top.md`, frontmatterType: "command" }),
+      makeFile({ id: "sub", sourcePath: `${BASE}/board/pickup-sub.md`, frontmatterType: "command" }),
+      makeFile({ id: "deep", sourcePath: `${BASE}/board/nested/deep.md`, frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["top"]);
+  });
+
+  it("drops top-level files with a non-matching frontmatter type", () => {
+    const files = [
+      makeFile({ id: "cmd", sourcePath: `${BASE}/hatch3r-cmd.md`, frontmatterType: "command" }),
+      makeFile({ id: "shared", sourcePath: `${BASE}/hatch3r-shared.md`, frontmatterType: "shared-context" }),
+      makeFile({ id: "ref", sourcePath: `${BASE}/hatch3r-ref.md`, frontmatterType: "reference" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["cmd"]);
+  });
+
+  it("applies both signals to the agents bucket", () => {
+    const agentsBase = "/fake/agents/agents";
+    const files = [
+      makeFile({ id: "agent", type: "agent", sourcePath: `${agentsBase}/hatch3r-agent.md`, frontmatterType: "agent" }),
+      makeFile({ id: "mode", type: "agent", sourcePath: `${agentsBase}/modes/fake-mode.md`, frontmatterType: "mode" }),
+      makeFile({ id: "shared", type: "agent", sourcePath: `${agentsBase}/shared/fake-ref.md`, frontmatterType: "reference" }),
+      makeFile({ id: "top-ref", type: "agent", sourcePath: `${agentsBase}/hatch3r-ref.md`, frontmatterType: "reference" }),
+    ];
+    const result = filterUserFacing(files, "agent", agentsBase);
+    expect(result.map((f) => f.id)).toEqual(["agent"]);
+  });
+
+  it("keeps legacy top-level files that lack a frontmatterType", () => {
+    const files = [
+      makeFile({ id: "legacy", sourcePath: `${BASE}/hatch3r-legacy.md` }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["legacy"]);
+  });
+
+  it("keeps files whose sourcePath lies outside the baseDir (safe default)", () => {
+    const files = [
+      makeFile({ id: "outside", sourcePath: "/somewhere/else/hatch3r-outside.md", frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["outside"]);
+  });
+
+  it("accepts a baseDir passed with or without a trailing slash", () => {
+    const files = [
+      makeFile({ id: "top", sourcePath: `${BASE}/hatch3r-top.md`, frontmatterType: "command" }),
+      makeFile({ id: "sub", sourcePath: `${BASE}/board/pickup.md`, frontmatterType: "command" }),
+    ];
+    expect(filterUserFacing(files, "command", BASE).map((f) => f.id)).toEqual(["top"]);
+    expect(filterUserFacing(files, "command", `${BASE}/`).map((f) => f.id)).toEqual(["top"]);
   });
 });

--- a/src/__tests__/adapters/claude.test.ts
+++ b/src/__tests__/adapters/claude.test.ts
@@ -89,6 +89,30 @@ describe("ClaudeAdapter", () => {
     expect(agent.managedContent).toBeDefined();
   });
 
+  it("filters companion agent content (modes/shared) and command content (subdirectory/shared-context) from per-tool output", async () => {
+    const manifest = makeManifest();
+    const outputs = await adapter.generate(FIXTURES_DIR, manifest);
+
+    const agentPaths = outputs
+      .filter((o) => o.path.startsWith(".claude/agents/"))
+      .map((o) => o.path);
+    const commandPaths = outputs
+      .filter((o) => o.path.startsWith(".claude/commands/"))
+      .map((o) => o.path);
+
+    // Top-level primary fixtures survive
+    expect(agentPaths.some((p) => p.includes("test-agent"))).toBe(true);
+    expect(commandPaths.some((p) => p.includes("test-command"))).toBe(true);
+
+    // Subdirectory companion fixtures are excluded from pickers
+    expect(agentPaths.some((p) => p.includes("fake-mode"))).toBe(false);
+    expect(agentPaths.some((p) => p.includes("fake-reference"))).toBe(false);
+    expect(commandPaths.some((p) => p.includes("pickup-fake"))).toBe(false);
+
+    // Top-level file with non-primary frontmatter type is excluded
+    expect(commandPaths.some((p) => p.includes("fake-shared"))).toBe(false);
+  });
+
   it("includes Agent Teams section in CLAUDE.md", async () => {
     const manifest = makeManifest();
     const outputs = await adapter.generate(FIXTURES_DIR, manifest);

--- a/src/__tests__/adapters/gemini.test.ts
+++ b/src/__tests__/adapters/gemini.test.ts
@@ -246,6 +246,22 @@ describe("GeminiAdapter", () => {
     expect(commands.length).toBe(0);
   });
 
+  it("filters companion command content from .gemini/commands/ output", async () => {
+    const manifest = makeManifest();
+    const outputs = await adapter.generate(FIXTURES_DIR, manifest);
+
+    const commandPaths = outputs
+      .filter((o) => o.path.startsWith(".gemini/commands/"))
+      .map((o) => o.path);
+
+    // Top-level primary command survives
+    expect(commandPaths.some((p) => p.includes("test-command"))).toBe(true);
+    // Sub-workflow file under commands/board/ is dropped
+    expect(commandPaths.some((p) => p.includes("pickup-fake"))).toBe(false);
+    // Top-level shared-context file is dropped by frontmatter-type check
+    expect(commandPaths.some((p) => p.includes("fake-shared"))).toBe(false);
+  });
+
   // ── Wave B4: rule precedence ordering ──
   describe("rule precedence ordering", () => {
     let precedenceDir: string;

--- a/src/__tests__/fixtures/agents/agents/modes/fake-mode.md
+++ b/src/__tests__/fixtures/agents/agents/modes/fake-mode.md
@@ -1,0 +1,8 @@
+---
+id: fake-mode
+type: mode
+description: Subdirectory mode fixture — filter must exclude from agent pickers.
+---
+# Fake Mode
+
+Companion behavioural mode. Not a standalone user-invocable agent.

--- a/src/__tests__/fixtures/agents/agents/shared/fake-reference.md
+++ b/src/__tests__/fixtures/agents/agents/shared/fake-reference.md
@@ -1,0 +1,8 @@
+---
+id: fake-reference
+type: reference
+description: Subdirectory shared-reference fixture — filter must exclude from agent pickers.
+---
+# Fake Reference
+
+Cross-cutting reference content. Not a standalone user-invocable agent.

--- a/src/__tests__/fixtures/agents/commands/board/pickup-fake.md
+++ b/src/__tests__/fixtures/agents/commands/board/pickup-fake.md
@@ -1,0 +1,8 @@
+---
+id: pickup-fake
+type: command
+description: Subdirectory sub-workflow command fixture — filter must exclude from command pickers.
+---
+# Pickup Fake
+
+Workflow step invoked by a parent command. Not a standalone user-invocable command.

--- a/src/__tests__/fixtures/agents/commands/hatch3r-fake-shared.md
+++ b/src/__tests__/fixtures/agents/commands/hatch3r-fake-shared.md
@@ -1,0 +1,8 @@
+---
+id: hatch3r-fake-shared
+type: shared-context
+description: Top-level shared-context fixture — filter must exclude by frontmatter type even though path is at top level.
+---
+# Fake Shared
+
+Top-level companion content that must be filtered out by frontmatter type.

--- a/src/adapters/agentsmd.ts
+++ b/src/adapters/agentsmd.ts
@@ -34,7 +34,7 @@ export class AgentsMdAdapter extends BaseAdapter {
 
     // Agents section
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/amazonq.ts
+++ b/src/adapters/amazonq.ts
@@ -2,7 +2,6 @@ import type { AdapterOutput } from "../types.js";
 import { toPrefixedId } from "../types.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { BaseAdapter, output, type AdapterContext } from "./base.js";
-import { readCanonicalFiles } from "./canonical.js";
 import { applyCustomization } from "./customization.js";
 import type { HookEvent } from "../hooks/types.js";
 
@@ -80,7 +79,7 @@ export class AmazonQAdapter extends BaseAdapter {
     // Generate native Amazon Q custom agent descriptors in .amazonq/cli-agents/.
     // Each canonical agent maps to a JSON descriptor that Amazon Q discovers natively.
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,4 +1,4 @@
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   AdapterOutput,
   CanonicalFile,
@@ -9,7 +9,7 @@ import type {
 import { resolveAgentModel } from "../models/resolve.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { generateBridgeOrchestration } from "../cli/shared/agentsContent.js";
-import { readCanonicalFiles, sortByPrecedence, type CanonicalType } from "./canonical.js";
+import { filterUserFacing, readCanonicalFiles, sortByPrecedence, type CanonicalType } from "./canonical.js";
 import { applyCustomization, applyCustomizationRaw } from "./customization.js";
 import { readMcpConfig, transformEnvVarSyntax, type McpServerEntry } from "./mcp-utils.js";
 import { readHookDefinitions } from "../hooks/index.js";
@@ -173,6 +173,31 @@ export abstract class BaseAdapter implements Adapter {
     return files;
   }
 
+  /**
+   * Read canonical commands or agents and filter to only those that should
+   * appear in a tool's user-facing command/agent picker. Wraps
+   * {@link readCanonicalFiles} + {@link filterUserFacing} and applies
+   * provenance tracking only to the surviving files, so filtered-out
+   * companion content does not pollute the adapter's source-file manifest.
+   *
+   * Filter rules are documented on {@link filterUserFacing}: files in
+   * support subdirectories (`commands/board/`, `agents/modes/`, etc.) and
+   * top-level files with a non-primary frontmatter `type:` (e.g.
+   * `shared-context`, `reference`, `mode`) are excluded.
+   */
+  protected async readUserFacingCanonicalFiles(
+    agentsDir: string,
+    type: "commands" | "agents",
+  ): Promise<CanonicalFile[]> {
+    const files = await readCanonicalFiles(agentsDir, type, this.warnings);
+    const expectedType = type === "commands" ? "command" : "agent";
+    const filtered = filterUserFacing(files, expectedType, join(agentsDir, type));
+    for (const f of filtered) {
+      if (f.sourcePath) this._trackedSourceFiles.add(f.sourcePath);
+    }
+    return filtered;
+  }
+
   protected abstract doGenerate(ctx: AdapterContext): Promise<AdapterOutput[]>;
 
   /**
@@ -243,7 +268,7 @@ export abstract class BaseAdapter implements Adapter {
   ): Promise<string[]> {
     if (!ctx.features.agents) return [];
     const lines: string[] = [];
-    const agents = await this.readTrackedCanonicalFiles(ctx.agentsDir, "agents");
+    const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
     const minimal = this.isMinimal(ctx);
     for (const agent of agents) {
       const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
@@ -308,7 +333,10 @@ export abstract class BaseAdapter implements Adapter {
   ): Promise<AdapterOutput[]> {
     if (!ctx.features.commands) return [];
     const results: AdapterOutput[] = [];
-    const commands = await this.readTrackedCanonicalFiles(ctx.agentsDir, "commands");
+    // Filter out companion/reference content (shared-context, subdirectory
+    // workflow steps like commands/board/pickup-*) so they do not appear
+    // as user-invocable entries in the tool's command picker.
+    const commands = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "commands");
     for (const cmd of commands) {
       const { content, skip, warnings } = await applyCustomizationRaw(ctx.projectRoot, cmd);
       this.warnings.push(...warnings);

--- a/src/adapters/canonical.ts
+++ b/src/adapters/canonical.ts
@@ -52,6 +52,44 @@ export function sortByPrecedence<T extends { precedence?: string; id: string }>(
   });
 }
 
+/**
+ * Filter canonical files down to those that should appear as user-invocable
+ * entries in a tool's command/agent picker (e.g. `.claude/commands/`,
+ * `.cursor/commands/`, `.claude/agents/`).
+ *
+ * Two orthogonal signals combined with AND:
+ * 1. Top-level-only: the file's path relative to `baseDir` must not contain
+ *    a path separator. This excludes companion subdirectories such as
+ *    `commands/board/`, `commands/revision/`, `agents/modes/`, and
+ *    `agents/shared/` whose contents are sub-workflows or shared reference
+ *    material invoked by parent commands/agents, not directly by users.
+ * 2. Frontmatter-type whitelist: `frontmatterType` must be either absent
+ *    (legacy files lacking the field load unchanged) or equal to
+ *    `expectedFrontmatterType`. This catches the rare case of a top-level
+ *    companion file such as `commands/hatch3r-board-shared.md`
+ *    (`type: shared-context`) that sits next to the real commands but must
+ *    not be invocable.
+ *
+ * Canonical `.agents/` content (populated by `src/content/index.ts`)
+ * remains unfiltered, so parent commands can continue referencing
+ * companion files by name — this helper only gates per-tool adapter
+ * emission.
+ */
+export function filterUserFacing(
+  files: CanonicalFile[],
+  expectedFrontmatterType: "command" | "agent",
+  baseDir: string,
+): CanonicalFile[] {
+  const normalizedBase = baseDir.endsWith("/") ? baseDir : `${baseDir}/`;
+  return files.filter((file) => {
+    if (!file.sourcePath.startsWith(normalizedBase)) return true;
+    const relative = file.sourcePath.slice(normalizedBase.length);
+    if (relative.includes("/")) return false;
+    if (file.frontmatterType && file.frontmatterType !== expectedFrontmatterType) return false;
+    return true;
+  });
+}
+
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?$/;
 
 /**
@@ -189,6 +227,14 @@ export function parseFrontmatter(
 ): {
   metadata: CanonicalMetadata;
   content: string;
+  /**
+   * The author-declared `type:` value from frontmatter, or `undefined` when
+   * the field is absent or was a non-string. Distinct from `metadata.type`,
+   * which falls back to `"rule"` when absent — callers that need to
+   * distinguish "user declared type" from "parser default" (e.g. the
+   * adapter filter at {@link filterUserFacing}) should read this field.
+   */
+  rawType?: string;
 } {
   const match = rawContent.match(FRONTMATTER_REGEX);
   if (!match) {
@@ -205,6 +251,7 @@ export function parseFrontmatter(
     type: "rule",
     description: "",
   };
+  let rawType: string | undefined;
 
   if (parsed && typeof parsed === "object") {
     // C7.5-W2B2-H8: enforce type contract on security-relevant identity
@@ -218,6 +265,7 @@ export function parseFrontmatter(
       if (raw === undefined) continue;
       if (typeof raw === "string") {
         metadata[field] = raw;
+        if (field === "type") rawType = raw;
       } else if (typeMismatches) {
         typeMismatches.push(
           `${field} field must be a string, got ${describeYamlType(raw)} (value: ${JSON.stringify(raw)})`,
@@ -261,7 +309,7 @@ export function parseFrontmatter(
   metadata.type = metadata.type ?? "rule";
   metadata.description = metadata.description ?? "";
 
-  return { metadata, content: content ?? "" };
+  return { metadata, content: content ?? "", rawType };
 }
 
 /**
@@ -363,11 +411,19 @@ async function readSingleMd(
     return errorResult;
   }
 
-  const { metadata, content } = parsed;
+  const { metadata, content, rawType } = parsed;
   const id = metadata.id || metadata.name || fallbackId;
   const canonical: CanonicalFile = {
     id,
     type: fileType,
+    // Preserve the author-declared frontmatter `type` alongside the reader
+    // bucket so downstream filters (see `filterUserFacing`) can distinguish
+    // user-invocable commands/agents from companion content
+    // (`shared-context`, `reference`, `mode`) within the same directory.
+    // `rawType` is undefined when the author omitted `type:`, so files
+    // without an explicit declaration fall through the filter's
+    // back-compat path and are kept.
+    frontmatterType: rawType,
     description: metadata.description ?? "",
     scope: metadata.scope,
     model: metadata.model,

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -279,7 +279,7 @@ export class ClaudeAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/cline.ts
+++ b/src/adapters/cline.ts
@@ -25,7 +25,7 @@ export class ClineAdapter extends BaseAdapter {
 
     const customModes: ClineCustomMode[] = [];
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -80,7 +80,7 @@ export class CodexAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -107,7 +107,7 @@ jobs:
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -65,7 +65,7 @@ export class CursorAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,8 +1,9 @@
+import { join } from "node:path";
 import type { AdapterOutput } from "../types.js";
 import { toPrefixedId } from "../types.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { BaseAdapter, output, type AdapterContext } from "./base.js";
-import { readCanonicalFiles } from "./canonical.js";
+import { filterUserFacing, readCanonicalFiles } from "./canonical.js";
 import { applyCustomization } from "./customization.js";
 import type { HookEvent } from "../hooks/types.js";
 import { escapeTomlString } from "./toml-utils.js";
@@ -76,7 +77,8 @@ export class GeminiAdapter extends BaseAdapter {
     );
 
     if (ctx.features.commands) {
-      const commands = await readCanonicalFiles(ctx.agentsDir, "commands", this.warnings);
+      const commandsRaw = await readCanonicalFiles(ctx.agentsDir, "commands", this.warnings);
+      const commands = filterUserFacing(commandsRaw, "command", join(ctx.agentsDir, "commands"));
       for (const cmd of commands) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, cmd);
         this.warnings.push(...warnings);

--- a/src/adapters/goose.ts
+++ b/src/adapters/goose.ts
@@ -39,7 +39,7 @@ export class GooseAdapter extends BaseAdapter {
     // #123: Read agents once and reuse for both inline content and profile generation
     // to avoid double readCanonicalFiles + double applyCustomization.
     const agents = ctx.features.agents
-      ? await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings)
+      ? await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents")
       : [];
 
     const lines = [

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -104,7 +104,7 @@ export class OpenCodeAdapter extends BaseAdapter {
     results.push(output("opencode.json", JSON.stringify(opencodeConfig, null, 2)));
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/windsurf.ts
+++ b/src/adapters/windsurf.ts
@@ -59,7 +59,7 @@ export class WindsurfAdapter extends BaseAdapter {
    */
   private async windsurfAgentToolPolicies(ctx: AdapterContext): Promise<string[]> {
     if (!ctx.features.agents) return [];
-    const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+    const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
     const rows: string[] = [];
     for (const agent of agents) {
       const { skip } = await applyCustomization(ctx.projectRoot, agent);

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,16 @@ export type RulePrecedence = "critical" | "high" | "normal" | "low";
 export interface CanonicalFile {
   id: string;
   type: "rule" | "agent" | "skill" | "command" | "prompt" | "github-agent" | "hook" | "check" | "policy" | "learning";
+  /**
+   * Raw frontmatter `type:` value as declared by the author. Distinct from
+   * `type` above, which is the reader-category bucket set from the directory
+   * the file lives in. Used by adapter emission filters (see
+   * `filterUserFacing` in `src/adapters/canonical.ts`) to distinguish
+   * user-invocable commands/agents from companion content like
+   * `shared-context`, `reference`, and `mode` that lives in the same
+   * directory tree but must not appear in tool command/agent pickers.
+   */
+  frontmatterType?: string;
   description: string;
   scope?: string;
   model?: string;


### PR DESCRIPTION
## Summary

- Adds a `filterUserFacing` helper in `src/adapters/canonical.ts` so each tool adapter emits only user-invocable commands/agents. ~40 companion files (`type: shared-context` / `reference` / `mode` + `commands/board/pickup-*` + `commands/revision/*`) no longer appear as entries in Claude Code's slash-command picker, Cursor's command palette, or any other adapter's picker UI.
- `parseFrontmatter()` now returns `rawType?: string` so the filter can tell "author declared `type: command`" apart from "parser defaulted to rule". `CanonicalFile` gains a `frontmatterType?: string` field populated from that value.
- `BaseAdapter` gets a `readUserFacingCanonicalFiles()` wrapper (read + filter + provenance tracking) used by `processCommandsRaw`, `inlineAgents`, and every per-adapter agent-emission site (claude / cursor / copilot / opencode / codex / amazonq / goose / windsurf / cline / agentsmd); gemini calls `filterUserFacing` directly because it bypasses the base helper for TOML output.
- The `.agents/` canonical mirror is untouched, so parent commands referencing companion files by name (e.g. `hatch3r-board-init` reading `hatch3r-board-shared`) keep working.

## Base

This PR targets `release/1.6.1` (PR #59) so the diff shows only the 1.6.2 delta. Once #59 merges to `main`, GitHub will auto-rebase this PR's base to `main`.

## Test plan

- [x] `npm test` — 2,613 pass (was 2,604; +9 new tests: 7 `filterUserFacing` unit tests + 2 adapter-level filter tests)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (135 pre-existing warnings, none in changed files)
- [x] `npm run build` — success
- [x] `npm run inventory` — count probes still pass at the new version
- [ ] Manual smoke: run `npx hatch3r init` in a scratch repo with `--tools claude,cursor,gemini` and confirm `.claude/commands/`, `.cursor/commands/`, `.gemini/commands/`, and `.claude/agents/` contain only top-level primary files (no `pickup-*`, `shared-*`, `fake-mode`, `fake-reference`, or `hatch3r-board-shared`).

## Files changed (20 files, +274 / -29)

- Core: `src/types.ts`, `src/adapters/canonical.ts`, `src/adapters/base.ts`
- Adapters: `agentsmd`, `amazonq`, `claude`, `cline`, `codex`, `copilot`, `cursor`, `gemini`, `goose`, `opencode`, `windsurf` — each uses the new helper for agents; `processCommandsRaw` in `base.ts` covers claude/cursor/copilot/opencode/windsurf/cline for commands; `gemini.ts` applies `filterUserFacing` directly.
- Tests: `canonical.test.ts` (+7 unit tests, adjusted 2 `readCanonicalFiles` assertions), `claude.test.ts` (+1 filter test), `gemini.test.ts` (+1 filter test); 4 new fixture files under `src/__tests__/fixtures/agents/`.
- Release: `package.json`, `package-lock.json`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which canonical command/agent files get emitted across many adapters, so regressions could hide legitimate commands/agents or alter provenance tracking, though the underlying canonical read remains unchanged and behavior is well-covered by tests.
> 
> **Overview**
> Prevents companion markdown (sub-workflow files in subdirectories and top-level non-primary `type:` like `shared-context`/`reference`/`mode`) from being emitted as user-invocable entries in tool command/agent pickers by introducing `filterUserFacing()` and wiring it through `BaseAdapter` (`readUserFacingCanonicalFiles`, `processCommandsRaw`, `inlineAgents`) and all agent-emitting adapters (with Gemini filtering its TOML command output directly).
> 
> Extends canonical frontmatter parsing to preserve the author-declared `type:` separately (`rawType` → `CanonicalFile.frontmatterType`) so filtering can distinguish explicit types from parser defaults, and adds unit + adapter-level tests plus new fixtures to lock in the filtering behavior. Also bumps version to `1.6.2` and updates the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit febbef12bf5181d69521edd57aeb661599a7be4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->