### PR TITLE
release: v1.6.2 — full preset fix, init worktree prompt, hide companion content from tool pickers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hatch3r",
   "description": "Battle-tested agentic coding setup: 16 agents, 26 skills, 27 rules, 34 commands, 6 hooks, and MCP integrations. Counts derived from governance/inventory.json.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "hatch3r",
     "email": "support@hatch3r.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "hatch3r",
   "description": "Battle-tested agentic coding setup: 16 agents, 26 skills, 27 rules, 34 commands, 6 hooks, and MCP integrations. Counts derived from governance/inventory.json.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "hatch3r",
     "email": "support@hatch3r.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [1.6.2] - 2026-04-22
+
+### Fixed
+
+- **Companion content no longer clutters the tool command/agent picker**: `hatch3r init` / `hatch3r sync` previously emitted every `.md` file under `commands/` and `agents/` as a user-invocable entry in each tool's picker — including ~40 companion files (5 `type: shared-context`, 20 `agents/modes/*` with `type: mode`, 4 `agents/shared/*` with `type: reference`, 11 sub-workflow files under `commands/board/pickup-*` and `commands/revision/*`) that exist only to be referenced by parent commands/agents, not invoked directly. The recursive `readGlobMd()` (`src/adapters/canonical.ts:460`) still reads the full tree so cross-references continue to resolve, but a new `filterUserFacing()` helper gates per-adapter emission on two signals: the file's path relative to its content-type baseDir must have no subdirectory separator, **and** its frontmatter `type:` must match the reader bucket (`command` / `agent`) or be absent. Applied to `processCommandsRaw` and a new `readUserFacingCanonicalFiles` wrapper in `src/adapters/base.ts`, plus direct call sites in `gemini.ts` and each of the 10 agent-emitting adapters (claude, cursor, copilot, opencode, codex, amazonq, goose, windsurf, cline, agentsmd). The `.agents/` canonical mirror in `src/content/index.ts` is unchanged, so parent commands that read shared context by name keep working.
+- **`parseFrontmatter` now surfaces the author-declared type separately from the parser default**: `parseFrontmatter()` returns an additional `rawType?: string` that is `undefined` when `type:` is absent from frontmatter, distinct from `metadata.type` which falls back to `"rule"`. `CanonicalFile.frontmatterType` is populated from `rawType`, letting the adapter filter distinguish "user chose `type: command`" from "parser defaulted to rule" — a distinction the previous shape could not express.
+
+### Tests
+
+- 7 new unit tests for `filterUserFacing` in `src/__tests__/adapters/canonical.test.ts` covering top-level pass, subdirectory drop, frontmatter-type whitelist, both-signals-AND for agents, legacy back-compat for files without frontmatter `type:`, safe default when `sourcePath` lies outside `baseDir`, and trailing-slash tolerance on `baseDir`.
+- 2 new adapter-level filter tests (claude, gemini) asserting that subdirectory fixtures (`pickup-fake`, `fake-mode`, `fake-reference`) and top-level `type: shared-context` fixture (`hatch3r-fake-shared`) are absent from `.claude/commands/`, `.claude/agents/`, and `.gemini/commands/` output while the primary `test-agent` / `test-command` fixtures survive.
+- 4 new fixture files under `src/__tests__/fixtures/agents/` (`agents/modes/fake-mode.md`, `agents/shared/fake-reference.md`, `commands/board/pickup-fake.md`, `commands/hatch3r-fake-shared.md`) exercise both filter signals.
+- 2 existing `readCanonicalFiles` tests adjusted to reflect the now-intentionally-larger fixture set (the raw reader sees all files; filtering happens at the emission layer). Test count 2,604 → 2,613.
+
 ## [1.6.1] - 2026-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [1.6.1] - 2026-04-22
+
+### Fixed
+
+- **`full` preset now actually installs everything**: the default `hatch3r init` profile silently dropped the 6 `hatch3r-board-*` commands (pickup, groom, refresh, init, fill, shared) and `hatch3r-onboard` because the solo team-size filter ran unconditionally over the resolved selection, even when the user's chosen preset explicitly promised "Everything including board management". The filter now scopes to non-`full` presets — users who opt into `full` receive the full catalog regardless of `teamSize`. Project-type and language filters continue to apply (they are technical compatibility filters, not preferences). Fix: `src/content/index.ts::resolveSelection` guard at line 436.
+- **Worktree support now explicitly configurable in `init`**: previously `hatch3r init` auto-enabled worktree file isolation without prompting whenever a worktree-capable tool (currently `claude`) was selected, while `hatch3r config` did prompt — an asymmetric UX that hid a side-effect from interactive users. Init now mirrors the config prompt after tools selection and adds `--worktree` / `--no-worktree` CLI flags for headless callers. `--yes` without the flag preserves today's auto-enable behavior for CI compatibility. Fix: `src/cli/commands/init.ts` interactive and workspace branches; `src/cli/program.ts` flag registration; `src/manifest/hatchJson.ts::createManifest` honors explicit `worktreeEnabled` option. `src/cli/commands/clean.ts` reinit path threaded through the new option to keep `RunInitOptions` consistent.
+
+### Tests
+
+- 3 existing `resolveSelection` tests updated to reflect the new preset-aware semantic; 5 new tests cover `full + solo` behavior (keeps team/board items, still applies projectType filter, `standard + solo` unchanged as scope check, `skipContextFilters` path unchanged).
+- 5 new `init.test.ts` cases cover the worktree prompt paths (interactive accept, interactive decline, `--no-worktree` override, `--worktree` force-enable, no prompt when no worktree-capable tool). 13 existing interactive init tests updated to queue the new prompt where applicable. Test count 2,594 → 2,604.
+
 ## [1.6.0] - 2026-04-21
 
 ### Added

--- a/docs/adapter-capability-matrix.md
+++ b/docs/adapter-capability-matrix.md
@@ -1,6 +1,6 @@
 # Adapter Capability Matrix
 
-> **Last verified**: 2026-04-20 | **hatch3r version**: 1.6.0
+> **Last verified**: 2026-04-22 | **hatch3r version**: 1.6.1
 
 Living reference for framework capabilities vs. adapter implementations. This document tracks what each adapter emits, what each platform supports natively, and where gaps remain.
 

--- a/docs/marketplace-submission.md
+++ b/docs/marketplace-submission.md
@@ -77,7 +77,7 @@ The submission requires a valid `.claude-plugin/plugin.json`. The current manife
 {
   "name": "hatch3r",
   "description": "Battle-tested agentic coding setup: 16 agents, 26 skills, 27 rules, 34 commands, 6 hooks, and MCP integrations. Counts derived from governance/inventory.json.",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": {
     "name": "hatch3r",
     "email": "support@hatch3r.com"

--- a/docs/marketplace-submission.md
+++ b/docs/marketplace-submission.md
@@ -77,7 +77,7 @@ The submission requires a valid `.claude-plugin/plugin.json`. The current manife
 {
   "name": "hatch3r",
   "description": "Battle-tested agentic coding setup: 16 agents, 26 skills, 27 rules, 34 commands, 6 hooks, and MCP integrations. Counts derived from governance/inventory.json.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": {
     "name": "hatch3r",
     "email": "support@hatch3r.com"

--- a/governance/inventory.json
+++ b/governance/inventory.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-04-21",
+  "lastUpdated": "2026-04-22",
   "counts": {
     "adapters": 15,
     "agents": 16,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatch3r",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatch3r",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatch3r",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatch3r",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "boxen": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatch3r",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Battle-tested agentic coding setup framework. One command to hatch your agent stack -- agents, skills, rules, commands, and MCP for every major AI coding tool.",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatch3r",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Battle-tested agentic coding setup framework. One command to hatch your agent stack -- agents, skills, rules, commands, and MCP for every major AI coding tool.",
   "type": "module",
   "exports": {

--- a/src/__tests__/adapters/canonical.test.ts
+++ b/src/__tests__/adapters/canonical.test.ts
@@ -938,4 +938,22 @@ describe("filterUserFacing", () => {
     expect(filterUserFacing(files, "command", BASE).map((f) => f.id)).toEqual(["top"]);
     expect(filterUserFacing(files, "command", `${BASE}/`).map((f) => f.id)).toEqual(["top"]);
   });
+
+  it("drops files whose relative path contains a backslash (Windows separator)", () => {
+    // Regression guard: on Windows, `node:path.relative` returns a
+    // backslash-separated string. Earlier versions of this helper only
+    // checked `/`, which meant every subdirectory companion file slipped
+    // through and leaked into the user-facing picker on Windows CI runs.
+    // We validate the separator-agnostic logic by placing a synthetic
+    // backslash-separated path under a baseDir that resolves to the same
+    // directory on POSIX, so `path.relative` returns the raw basename
+    // and the `\\` stays inside the file name (which the filter treats
+    // as a subdirectory marker).
+    const files = [
+      makeFile({ id: "top", sourcePath: `${BASE}/hatch3r-top.md`, frontmatterType: "command" }),
+      makeFile({ id: "winsub", sourcePath: `${BASE}/board\\pickup.md`, frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["top"]);
+  });
 });

--- a/src/__tests__/adapters/canonical.test.ts
+++ b/src/__tests__/adapters/canonical.test.ts
@@ -3,11 +3,13 @@ import { mkdtemp, mkdir, writeFile, rm, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  filterUserFacing,
   readCanonicalFiles,
   readCanonicalFilesDetailed,
   precedenceRank,
   sortByPrecedence,
 } from "../../adapters/canonical.js";
+import type { CanonicalFile } from "../../types.js";
 import { resolveTestPath } from "../fixtures.js";
 
 const FIXTURES_DIR = resolveTestPath(import.meta.url, "../fixtures/agents");
@@ -97,13 +99,18 @@ describe("readCanonicalFiles", () => {
   });
 
   describe("agents", () => {
-    it("should read agents from agents/ directory", async () => {
+    it("should read agents from agents/ directory (including subdirectories)", async () => {
       const results = await readCanonicalFiles(FIXTURES_DIR, "agents");
 
-      expect(results.length).toBe(2);
+      // The raw read is recursive by design so subdirectory companion
+      // content (modes, shared reference) remains readable by parent
+      // commands. Adapter filtering (`filterUserFacing`) happens later
+      // at the emission layer.
       const ids = results.map((r) => r.id);
       expect(ids).toContain("test-agent");
       expect(ids).toContain("readonly-agent");
+      expect(ids).toContain("fake-mode");
+      expect(ids).toContain("fake-reference");
       for (const r of results) {
         expect(r.type).toBe("agent");
       }
@@ -178,13 +185,20 @@ describe("readCanonicalFiles", () => {
   });
 
   describe("commands", () => {
-    it("should read commands from commands/ directory", async () => {
+    it("should read commands from commands/ directory (including subdirectories)", async () => {
       const results = await readCanonicalFiles(FIXTURES_DIR, "commands");
 
-      expect(results.length).toBe(1);
-      expect(results[0]!.id).toBe("test-command");
-      expect(results[0]!.type).toBe("command");
-      expect(results[0]!.description).toBe("A test command for unit testing");
+      // The raw read is recursive by design. The filter fixtures
+      // (`pickup-fake` in a subdir, `hatch3r-fake-shared` with type
+      // `shared-context`) appear here but are stripped by the per-adapter
+      // `filterUserFacing` step.
+      const ids = results.map((r) => r.id);
+      expect(ids).toContain("test-command");
+      expect(ids).toContain("pickup-fake");
+      expect(ids).toContain("hatch3r-fake-shared");
+      const primary = results.find((r) => r.id === "test-command")!;
+      expect(primary.type).toBe("command");
+      expect(primary.description).toBe("A test command for unit testing");
     });
 
     it("should handle empty commands directory", async () => {
@@ -841,5 +855,87 @@ describe("parseFrontmatter precedence field", () => {
     const results = await readCanonicalFiles(tempDir, "rules");
     expect(results).toHaveLength(1);
     expect(results[0]!.precedence).toBeUndefined();
+  });
+});
+
+describe("filterUserFacing", () => {
+  const BASE = "/fake/agents/commands";
+
+  function makeFile(
+    overrides: Partial<CanonicalFile> & Pick<CanonicalFile, "id" | "sourcePath">,
+  ): CanonicalFile {
+    return {
+      type: "command",
+      description: "",
+      content: "",
+      rawContent: "",
+      ...overrides,
+    };
+  }
+
+  it("keeps top-level files whose frontmatter type matches the expected bucket", () => {
+    const files = [
+      makeFile({ id: "a", sourcePath: `${BASE}/hatch3r-a.md`, frontmatterType: "command" }),
+      makeFile({ id: "b", sourcePath: `${BASE}/hatch3r-b.md`, frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["a", "b"]);
+  });
+
+  it("drops files whose relative path contains a subdirectory separator", () => {
+    const files = [
+      makeFile({ id: "top", sourcePath: `${BASE}/hatch3r-top.md`, frontmatterType: "command" }),
+      makeFile({ id: "sub", sourcePath: `${BASE}/board/pickup-sub.md`, frontmatterType: "command" }),
+      makeFile({ id: "deep", sourcePath: `${BASE}/board/nested/deep.md`, frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["top"]);
+  });
+
+  it("drops top-level files with a non-matching frontmatter type", () => {
+    const files = [
+      makeFile({ id: "cmd", sourcePath: `${BASE}/hatch3r-cmd.md`, frontmatterType: "command" }),
+      makeFile({ id: "shared", sourcePath: `${BASE}/hatch3r-shared.md`, frontmatterType: "shared-context" }),
+      makeFile({ id: "ref", sourcePath: `${BASE}/hatch3r-ref.md`, frontmatterType: "reference" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["cmd"]);
+  });
+
+  it("applies both signals to the agents bucket", () => {
+    const agentsBase = "/fake/agents/agents";
+    const files = [
+      makeFile({ id: "agent", type: "agent", sourcePath: `${agentsBase}/hatch3r-agent.md`, frontmatterType: "agent" }),
+      makeFile({ id: "mode", type: "agent", sourcePath: `${agentsBase}/modes/fake-mode.md`, frontmatterType: "mode" }),
+      makeFile({ id: "shared", type: "agent", sourcePath: `${agentsBase}/shared/fake-ref.md`, frontmatterType: "reference" }),
+      makeFile({ id: "top-ref", type: "agent", sourcePath: `${agentsBase}/hatch3r-ref.md`, frontmatterType: "reference" }),
+    ];
+    const result = filterUserFacing(files, "agent", agentsBase);
+    expect(result.map((f) => f.id)).toEqual(["agent"]);
+  });
+
+  it("keeps legacy top-level files that lack a frontmatterType", () => {
+    const files = [
+      makeFile({ id: "legacy", sourcePath: `${BASE}/hatch3r-legacy.md` }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["legacy"]);
+  });
+
+  it("keeps files whose sourcePath lies outside the baseDir (safe default)", () => {
+    const files = [
+      makeFile({ id: "outside", sourcePath: "/somewhere/else/hatch3r-outside.md", frontmatterType: "command" }),
+    ];
+    const result = filterUserFacing(files, "command", BASE);
+    expect(result.map((f) => f.id)).toEqual(["outside"]);
+  });
+
+  it("accepts a baseDir passed with or without a trailing slash", () => {
+    const files = [
+      makeFile({ id: "top", sourcePath: `${BASE}/hatch3r-top.md`, frontmatterType: "command" }),
+      makeFile({ id: "sub", sourcePath: `${BASE}/board/pickup.md`, frontmatterType: "command" }),
+    ];
+    expect(filterUserFacing(files, "command", BASE).map((f) => f.id)).toEqual(["top"]);
+    expect(filterUserFacing(files, "command", `${BASE}/`).map((f) => f.id)).toEqual(["top"]);
   });
 });

--- a/src/__tests__/adapters/capability-matrix.test.ts
+++ b/src/__tests__/adapters/capability-matrix.test.ts
@@ -146,7 +146,7 @@ interface ObservedCapabilityRow {
 function declaredSupport(tool: string, feature: keyof Features): boolean {
   const manifest: HatchManifest = {
     version: "2.0.0",
-    hatch3rVersion: "1.6.0",
+    hatch3rVersion: "1.6.1",
     platform: "github",
     owner: "",
     repo: "",

--- a/src/__tests__/adapters/claude.test.ts
+++ b/src/__tests__/adapters/claude.test.ts
@@ -89,6 +89,30 @@ describe("ClaudeAdapter", () => {
     expect(agent.managedContent).toBeDefined();
   });
 
+  it("filters companion agent content (modes/shared) and command content (subdirectory/shared-context) from per-tool output", async () => {
+    const manifest = makeManifest();
+    const outputs = await adapter.generate(FIXTURES_DIR, manifest);
+
+    const agentPaths = outputs
+      .filter((o) => o.path.startsWith(".claude/agents/"))
+      .map((o) => o.path);
+    const commandPaths = outputs
+      .filter((o) => o.path.startsWith(".claude/commands/"))
+      .map((o) => o.path);
+
+    // Top-level primary fixtures survive
+    expect(agentPaths.some((p) => p.includes("test-agent"))).toBe(true);
+    expect(commandPaths.some((p) => p.includes("test-command"))).toBe(true);
+
+    // Subdirectory companion fixtures are excluded from pickers
+    expect(agentPaths.some((p) => p.includes("fake-mode"))).toBe(false);
+    expect(agentPaths.some((p) => p.includes("fake-reference"))).toBe(false);
+    expect(commandPaths.some((p) => p.includes("pickup-fake"))).toBe(false);
+
+    // Top-level file with non-primary frontmatter type is excluded
+    expect(commandPaths.some((p) => p.includes("fake-shared"))).toBe(false);
+  });
+
   it("includes Agent Teams section in CLAUDE.md", async () => {
     const manifest = makeManifest();
     const outputs = await adapter.generate(FIXTURES_DIR, manifest);

--- a/src/__tests__/adapters/gemini.test.ts
+++ b/src/__tests__/adapters/gemini.test.ts
@@ -246,6 +246,22 @@ describe("GeminiAdapter", () => {
     expect(commands.length).toBe(0);
   });
 
+  it("filters companion command content from .gemini/commands/ output", async () => {
+    const manifest = makeManifest();
+    const outputs = await adapter.generate(FIXTURES_DIR, manifest);
+
+    const commandPaths = outputs
+      .filter((o) => o.path.startsWith(".gemini/commands/"))
+      .map((o) => o.path);
+
+    // Top-level primary command survives
+    expect(commandPaths.some((p) => p.includes("test-command"))).toBe(true);
+    // Sub-workflow file under commands/board/ is dropped
+    expect(commandPaths.some((p) => p.includes("pickup-fake"))).toBe(false);
+    // Top-level shared-context file is dropped by frontmatter-type check
+    expect(commandPaths.some((p) => p.includes("fake-shared"))).toBe(false);
+  });
+
   // ── Wave B4: rule precedence ordering ──
   describe("rule precedence ordering", () => {
     let precedenceDir: string;

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -69,7 +69,7 @@ describe("init command", () => {
     const manifest = JSON.parse(raw);
 
     expect(manifest.version).toBe("2.0.0");
-    expect(manifest.hatch3rVersion).toBe("1.6.1");
+    expect(manifest.hatch3rVersion).toBe("1.6.2");
     expect(manifest.platform).toBe("github");
     expect(Array.isArray(manifest.tools)).toBe(true);
     expect(manifest.tools.length).toBeGreaterThan(0);
@@ -240,7 +240,7 @@ describe("init command", () => {
     await initCommand({ yes: true });
 
     const manifest = JSON.parse(await readFile(join(agentsDir, "hatch.json"), "utf-8"));
-    expect(manifest.hatch3rVersion).toBe("1.6.1");
+    expect(manifest.hatch3rVersion).toBe("1.6.2");
   });
 
   it("should include AGENTS.md in managedFiles", async () => {

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -69,7 +69,7 @@ describe("init command", () => {
     const manifest = JSON.parse(raw);
 
     expect(manifest.version).toBe("2.0.0");
-    expect(manifest.hatch3rVersion).toBe("1.6.0");
+    expect(manifest.hatch3rVersion).toBe("1.6.1");
     expect(manifest.platform).toBe("github");
     expect(Array.isArray(manifest.tools)).toBe(true);
     expect(manifest.tools.length).toBeGreaterThan(0);
@@ -240,7 +240,7 @@ describe("init command", () => {
     await initCommand({ yes: true });
 
     const manifest = JSON.parse(await readFile(join(agentsDir, "hatch.json"), "utf-8"));
-    expect(manifest.hatch3rVersion).toBe("1.6.0");
+    expect(manifest.hatch3rVersion).toBe("1.6.1");
   });
 
   it("should include AGENTS.md in managedFiles", async () => {

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, writeFile, readFile, rm, access } from "node:fs/promise
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { HatchError } from "../../types.js";
+import { HATCH3R_VERSION } from "../../version.js";
 
 // Mock inquirer so interactive paths can be exercised. The --yes paths in
 // initCommand do not call inquirer.prompt, so existing non-interactive tests
@@ -69,7 +70,7 @@ describe("init command", () => {
     const manifest = JSON.parse(raw);
 
     expect(manifest.version).toBe("2.0.0");
-    expect(manifest.hatch3rVersion).toBe("1.6.2");
+    expect(manifest.hatch3rVersion).toBe(HATCH3R_VERSION);
     expect(manifest.platform).toBe("github");
     expect(Array.isArray(manifest.tools)).toBe(true);
     expect(manifest.tools.length).toBeGreaterThan(0);
@@ -240,7 +241,7 @@ describe("init command", () => {
     await initCommand({ yes: true });
 
     const manifest = JSON.parse(await readFile(join(agentsDir, "hatch.json"), "utf-8"));
-    expect(manifest.hatch3rVersion).toBe("1.6.2");
+    expect(manifest.hatch3rVersion).toBe(HATCH3R_VERSION);
   });
 
   it("should include AGENTS.md in managedFiles", async () => {

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -739,7 +739,7 @@ describe("init re-init: stale content cleanup", () => {
 });
 
 describe("init worktree generation (claude tool present)", () => {
-  let initCommand: (opts?: { tools?: string; yes?: boolean }) => Promise<void>;
+  let initCommand: (opts?: { tools?: string; yes?: boolean; worktree?: boolean }) => Promise<void>;
   let tempDir: string;
   let cwdSpy: MockInstance;
   let exitSpy: MockInstance;
@@ -760,6 +760,7 @@ describe("init worktree generation (claude tool present)", () => {
       }) as never);
     consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(inquirer.prompt).mockReset();
   });
 
   afterEach(async () => {
@@ -790,6 +791,62 @@ describe("init worktree generation (claude tool present)", () => {
     await expect(
       access(join(tempDir, ".worktreeinclude")),
     ).rejects.toThrow();
+  });
+
+  // v1.6.1 Fix 2: --worktree / --no-worktree flags + interactive prompt.
+  // Queue the interactive single-repo prompt sequence for tests that rely on it.
+  function queueInteractiveWithWorktree(opts: { tools?: string[]; worktree?: boolean } = {}): void {
+    const inq = vi.mocked(inquirer.prompt);
+    const tools = opts.tools ?? ["claude"];
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "test-owner", repo: "test-repo" });
+    inq.mockResolvedValueOnce({ defaultBranch: "main" });
+    inq.mockResolvedValueOnce({ projectType: "brownfield" });
+    inq.mockResolvedValueOnce({ teamSize: "solo" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ tools });
+    if (tools.includes("claude") && opts.worktree !== undefined) {
+      inq.mockResolvedValueOnce({ enabled: opts.worktree });
+    } else if (tools.includes("claude")) {
+      inq.mockResolvedValueOnce({ enabled: true });
+    }
+    inq.mockResolvedValueOnce({ features: ["agents"] });
+  }
+
+  it("interactive init prompts for worktree when a worktree-capable tool is selected", async () => {
+    queueInteractiveWithWorktree({ tools: ["claude"], worktree: true });
+    await initCommand();
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.worktree?.enabled).toBe(true);
+    await expect(access(join(tempDir, ".worktreeinclude"))).resolves.toBeUndefined();
+  });
+
+  it("interactive init respects declining worktree prompt", async () => {
+    queueInteractiveWithWorktree({ tools: ["claude"], worktree: false });
+    await initCommand();
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.worktree).toBeUndefined();
+    await expect(access(join(tempDir, ".worktreeinclude"))).rejects.toThrow();
+  });
+
+  it("--yes --no-worktree disables worktree even when claude is selected", async () => {
+    await initCommand({ yes: true, tools: "claude", worktree: false });
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.worktree).toBeUndefined();
+    await expect(access(join(tempDir, ".worktreeinclude"))).rejects.toThrow();
+  });
+
+  it("--yes --worktree enables worktree even when no worktree-capable tool is selected", async () => {
+    await initCommand({ yes: true, tools: "amp", worktree: true });
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.worktree?.enabled).toBe(true);
+  });
+
+  it("interactive init does not prompt for worktree when no worktree-capable tool is selected", async () => {
+    queueInteractiveWithWorktree({ tools: ["amp"] });
+    await initCommand();
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.worktree).toBeUndefined();
   });
 });
 
@@ -908,7 +965,10 @@ describe("init interactive single-repo flow", () => {
 
   /**
    * Queue prompt responses for the interactive single-repo flow.
-   * Order matches the prompts in initCommand() lines 500-707.
+   * Prompt order: platform -> owner/repo -> defaultBranch -> projectType ->
+   * teamSize -> preset -> [custom items] -> tools -> [worktree] -> features -> [mcp].
+   * The worktree prompt fires only when a worktree-capable tool (e.g. claude)
+   * is in the selected tools list.
    */
   function setupGithubInteractive(opts: {
     preset?: "minimal" | "standard" | "full" | "custom";
@@ -918,8 +978,10 @@ describe("init interactive single-repo flow", () => {
     features?: string[];
     mcpServers?: string[];
     customItems?: string[];
+    worktree?: boolean;
   } = {}): void {
     const inq = vi.mocked(inquirer.prompt);
+    const tools = opts.tools ?? ["claude"];
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "test-owner", repo: "test-repo" });
     inq.mockResolvedValueOnce({ defaultBranch: "main" });
@@ -929,7 +991,12 @@ describe("init interactive single-repo flow", () => {
     if (opts.preset === "custom") {
       inq.mockResolvedValueOnce({ items: opts.customItems ?? [] });
     }
-    inq.mockResolvedValueOnce({ tools: opts.tools ?? ["claude"] });
+    inq.mockResolvedValueOnce({ tools });
+    // Worktree prompt fires only when a worktree-capable tool is selected.
+    // WORKTREE_CAPABLE_TOOLS currently = new Set(["claude"]).
+    if (tools.includes("claude")) {
+      inq.mockResolvedValueOnce({ enabled: opts.worktree ?? true });
+    }
     inq.mockResolvedValueOnce({
       features: opts.features ?? ["agents", "skills", "rules", "prompts", "commands", "mcp", "githubAgents", "hooks"],
     });
@@ -976,6 +1043,7 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt
     inq.mockResolvedValueOnce({ features: ["agents"] });
 
     await initCommand({});
@@ -997,6 +1065,7 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt
     inq.mockResolvedValueOnce({ features: ["agents"] });
 
     await initCommand({});
@@ -1018,8 +1087,10 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ projectType: "brownfield" });
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
-    // Empty tool selection -> falls back to DEFAULT_TOOLS
+    // Empty tool selection -> falls back to DEFAULT_TOOLS (= ["claude"])
     inq.mockResolvedValueOnce({ tools: [] });
+    // tools fall-through to ["claude"] triggers the worktree prompt
+    inq.mockResolvedValueOnce({ enabled: true });
     inq.mockResolvedValueOnce({ features: ["agents"] });
 
     await initCommand({});
@@ -1057,6 +1128,7 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
     // The checkExisting prompt — accept overwrite
     inq.mockResolvedValueOnce({ proceed: true });
@@ -1084,6 +1156,7 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
     // Reject overwrite
     inq.mockResolvedValueOnce({ proceed: false });
@@ -1148,6 +1221,8 @@ describe("init interactive workspace flow", () => {
     inq.mockResolvedValueOnce({ preset: "minimal" });
     // 6) Tools
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    // 6b) Worktree prompt (claude selected)
+    inq.mockResolvedValueOnce({ enabled: true });
     // 7) Features
     inq.mockResolvedValueOnce({ features: ["agents"] });
     // 8) Repo selection for sync
@@ -1174,6 +1249,7 @@ describe("init interactive workspace flow", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
 
     await initCommand({});
@@ -1205,6 +1281,8 @@ describe("init interactive workspace flow", () => {
     inq.mockResolvedValueOnce({ preset: "minimal" });
     // 7) Tools
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    // 7b) Worktree prompt (claude selected)
+    inq.mockResolvedValueOnce({ enabled: true });
     // 8) Features
     inq.mockResolvedValueOnce({ features: ["agents"] });
     // 9) Repo sync selection
@@ -1383,6 +1461,7 @@ describe("init eager flag validation (C8-D1-M4)", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
 
     await initCommand({ preset: "minimal" });
@@ -1453,6 +1532,7 @@ describe("init runInit idempotency guard (C8-D1-M3)", () => {
       mcpServers: [],
       repoInfo,
       contentSelection,
+      worktreeEnabled: false,
     };
 
     // Fire two concurrent runInit calls. The second should reject with the
@@ -1531,6 +1611,7 @@ describe("init workspace conflict guard (C8-D1-M3)", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
     // Select the repo with existing hatch3r for sync (triggers conflict prompt)
     inq.mockResolvedValueOnce({ syncRepos: ["api"] });
@@ -1556,6 +1637,7 @@ describe("init workspace conflict guard (C8-D1-M3)", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
     inq.mockResolvedValueOnce({ syncRepos: ["api"] });
     inq.mockResolvedValueOnce({ confirmConflict: true });
@@ -1577,6 +1659,7 @@ describe("init workspace conflict guard (C8-D1-M3)", () => {
     inq.mockResolvedValueOnce({ teamSize: "solo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ enabled: true }); // worktree prompt (claude selected)
     inq.mockResolvedValueOnce({ features: ["agents"] });
     inq.mockResolvedValueOnce({ syncRepos: ["api"] });
     // NO confirmConflict prompt expected here

--- a/src/__tests__/cli/lifecycle.test.ts
+++ b/src/__tests__/cli/lifecycle.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { HatchError } from "../../types.js";
+import { HATCH3R_VERSION } from "../../version.js";
 
 // Mock child_process to prevent actual git/npx calls from update command
 vi.mock("node:child_process", async (importOriginal) => {
@@ -91,7 +92,7 @@ describe("init -> sync -> update lifecycle", { timeout: 60_000 }, () => {
     // Verify update refreshed the manifest version
     const updatedManifestRaw = await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8");
     const updatedManifest = JSON.parse(updatedManifestRaw);
-    expect(updatedManifest.hatch3rVersion).toBe("1.6.2");
+    expect(updatedManifest.hatch3rVersion).toBe(HATCH3R_VERSION);
 
     // Verify adapter output was regenerated
     const updatedBridge = await readFile(bridgePath, "utf-8").catch(() => null);

--- a/src/__tests__/cli/lifecycle.test.ts
+++ b/src/__tests__/cli/lifecycle.test.ts
@@ -91,7 +91,7 @@ describe("init -> sync -> update lifecycle", { timeout: 60_000 }, () => {
     // Verify update refreshed the manifest version
     const updatedManifestRaw = await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8");
     const updatedManifest = JSON.parse(updatedManifestRaw);
-    expect(updatedManifest.hatch3rVersion).toBe("1.6.1");
+    expect(updatedManifest.hatch3rVersion).toBe("1.6.2");
 
     // Verify adapter output was regenerated
     const updatedBridge = await readFile(bridgePath, "utf-8").catch(() => null);

--- a/src/__tests__/cli/lifecycle.test.ts
+++ b/src/__tests__/cli/lifecycle.test.ts
@@ -91,7 +91,7 @@ describe("init -> sync -> update lifecycle", { timeout: 60_000 }, () => {
     // Verify update refreshed the manifest version
     const updatedManifestRaw = await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8");
     const updatedManifest = JSON.parse(updatedManifestRaw);
-    expect(updatedManifest.hatch3rVersion).toBe("1.6.0");
+    expect(updatedManifest.hatch3rVersion).toBe("1.6.1");
 
     // Verify adapter output was regenerated
     const updatedBridge = await readFile(bridgePath, "utf-8").catch(() => null);

--- a/src/__tests__/cli/migration-checkpoints.test.ts
+++ b/src/__tests__/cli/migration-checkpoints.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { HatchError, DEFAULT_FEATURES, type HatchManifest, type ContentSelection } from "../../types.js";
+import { HATCH3R_VERSION } from "../../version.js";
 
 // ── Mock dependencies before imports ───────────────────────────
 
@@ -273,7 +274,7 @@ describe("migration checkpoints", () => {
   describe("fully migrated manifest", () => {
     it("should trigger no checkpoints when manifest is complete", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.2",
+        hatch3rVersion: HATCH3R_VERSION,
         platform: "github",
         content: makeContentSelection(),
       });
@@ -445,7 +446,7 @@ describe("migration checkpoints", () => {
 
       const manifestPath = join(tempDir, AGENTS_DIR, "hatch.json");
       const updated = JSON.parse(await readFile(manifestPath, "utf-8"));
-      expect(updated.hatch3rVersion).toBe("1.6.2");
+      expect(updated.hatch3rVersion).toBe(HATCH3R_VERSION);
 
       const allOutput = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(allOutput).toContain("Update complete");
@@ -456,7 +457,7 @@ describe("migration checkpoints", () => {
   describe("update flow when manifest is already up-to-date", () => {
     it("should note already at latest version and still complete update", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.2",
+        hatch3rVersion: HATCH3R_VERSION,
         platform: "github",
         content: makeContentSelection(),
       });

--- a/src/__tests__/cli/migration-checkpoints.test.ts
+++ b/src/__tests__/cli/migration-checkpoints.test.ts
@@ -273,7 +273,7 @@ describe("migration checkpoints", () => {
   describe("fully migrated manifest", () => {
     it("should trigger no checkpoints when manifest is complete", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.0",
+        hatch3rVersion: "1.6.1",
         platform: "github",
         content: makeContentSelection(),
       });
@@ -445,7 +445,7 @@ describe("migration checkpoints", () => {
 
       const manifestPath = join(tempDir, AGENTS_DIR, "hatch.json");
       const updated = JSON.parse(await readFile(manifestPath, "utf-8"));
-      expect(updated.hatch3rVersion).toBe("1.6.0");
+      expect(updated.hatch3rVersion).toBe("1.6.1");
 
       const allOutput = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(allOutput).toContain("Update complete");
@@ -456,7 +456,7 @@ describe("migration checkpoints", () => {
   describe("update flow when manifest is already up-to-date", () => {
     it("should note already at latest version and still complete update", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.0",
+        hatch3rVersion: "1.6.1",
         platform: "github",
         content: makeContentSelection(),
       });

--- a/src/__tests__/cli/migration-checkpoints.test.ts
+++ b/src/__tests__/cli/migration-checkpoints.test.ts
@@ -273,7 +273,7 @@ describe("migration checkpoints", () => {
   describe("fully migrated manifest", () => {
     it("should trigger no checkpoints when manifest is complete", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.1",
+        hatch3rVersion: "1.6.2",
         platform: "github",
         content: makeContentSelection(),
       });
@@ -445,7 +445,7 @@ describe("migration checkpoints", () => {
 
       const manifestPath = join(tempDir, AGENTS_DIR, "hatch.json");
       const updated = JSON.parse(await readFile(manifestPath, "utf-8"));
-      expect(updated.hatch3rVersion).toBe("1.6.1");
+      expect(updated.hatch3rVersion).toBe("1.6.2");
 
       const allOutput = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
       expect(allOutput).toContain("Update complete");
@@ -456,7 +456,7 @@ describe("migration checkpoints", () => {
   describe("update flow when manifest is already up-to-date", () => {
     it("should note already at latest version and still complete update", async () => {
       await createTestProject(tempDir, {
-        hatch3rVersion: "1.6.1",
+        hatch3rVersion: "1.6.2",
         platform: "github",
         content: makeContentSelection(),
       });

--- a/src/__tests__/cli/update.test.ts
+++ b/src/__tests__/cli/update.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { execFileSync } from "node:child_process";
 import { HatchError } from "../../types.js";
+import { HATCH3R_VERSION } from "../../version.js";
 
 vi.mock("node:child_process", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:child_process")>();
@@ -116,7 +117,7 @@ describe("update command", () => {
     const manifest = JSON.parse(
       await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"),
     );
-    expect(manifest.hatch3rVersion).toBe("1.6.2");
+    expect(manifest.hatch3rVersion).toBe(HATCH3R_VERSION);
   });
 
   it("should copy hatch3r-prefixed files from pack", async () => {
@@ -168,7 +169,7 @@ describe("update command", () => {
   });
 
   it("should note when already at latest version", async () => {
-    await createTestProject(tempDir, { hatch3rVersion: "1.6.2" });
+    await createTestProject(tempDir, { hatch3rVersion: HATCH3R_VERSION });
 
     const { updateCommand } = await import("../../cli/commands/update.js");
     await updateCommand({ backup: false });

--- a/src/__tests__/cli/update.test.ts
+++ b/src/__tests__/cli/update.test.ts
@@ -116,7 +116,7 @@ describe("update command", () => {
     const manifest = JSON.parse(
       await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"),
     );
-    expect(manifest.hatch3rVersion).toBe("1.6.0");
+    expect(manifest.hatch3rVersion).toBe("1.6.1");
   });
 
   it("should copy hatch3r-prefixed files from pack", async () => {
@@ -168,7 +168,7 @@ describe("update command", () => {
   });
 
   it("should note when already at latest version", async () => {
-    await createTestProject(tempDir, { hatch3rVersion: "1.6.0" });
+    await createTestProject(tempDir, { hatch3rVersion: "1.6.1" });
 
     const { updateCommand } = await import("../../cli/commands/update.js");
     await updateCommand({ backup: false });

--- a/src/__tests__/cli/update.test.ts
+++ b/src/__tests__/cli/update.test.ts
@@ -116,7 +116,7 @@ describe("update command", () => {
     const manifest = JSON.parse(
       await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"),
     );
-    expect(manifest.hatch3rVersion).toBe("1.6.1");
+    expect(manifest.hatch3rVersion).toBe("1.6.2");
   });
 
   it("should copy hatch3r-prefixed files from pack", async () => {
@@ -168,7 +168,7 @@ describe("update command", () => {
   });
 
   it("should note when already at latest version", async () => {
-    await createTestProject(tempDir, { hatch3rVersion: "1.6.1" });
+    await createTestProject(tempDir, { hatch3rVersion: "1.6.2" });
 
     const { updateCommand } = await import("../../cli/commands/update.js");
     await updateCommand({ backup: false });

--- a/src/__tests__/content/index.test.ts
+++ b/src/__tests__/content/index.test.ts
@@ -520,8 +520,8 @@ describe("content/index", () => {
       expect(allIds.has("bf-cmd")).toBe(true);
     });
 
-    it("solo teamSize removes items with only team/board tags", () => {
-      const preset = getPreset("full");
+    it("solo teamSize removes items with only team/board tags when preset is not 'full'", () => {
+      const preset = getPreset("standard");
       const selection = resolveSelection(preset, "brownfield", "solo", index);
 
       const allIds = getAllContentIds(selection);
@@ -591,15 +591,15 @@ describe("content/index", () => {
       expect(selection.teamSize).toBe("solo");
     });
 
-    it("full preset with greenfield+solo applies both context filters", () => {
+    it("full preset with greenfield+solo still applies projectType filter but not team filter", () => {
       const preset = getPreset("full");
       const selection = resolveSelection(preset, "greenfield", "solo", index);
 
       const allIds = getAllContentIds(selection);
-      // Brownfield-only removed
+      // Brownfield-only removed — projectType is a technical compatibility filter, still applies
       expect(allIds.has("bf-cmd")).toBe(false);
-      // Team-only removed
-      expect(allIds.has("team-only")).toBe(false);
+      // Team-only survives — full preset bypasses preference-based team-size filter
+      expect(allIds.has("team-only")).toBe(true);
       // Core agent survives both filters
       expect(allIds.has("core-agent")).toBe(true);
     });
@@ -676,7 +676,7 @@ describe("content/index", () => {
         relativePath: "commands/team-only-item.md",
       });
       const soloIndex = makeIndex([teamOnlyItem]);
-      const preset = getPreset("full");
+      const preset = getPreset("standard");
 
       const selection = resolveSelection(preset, "brownfield", "solo", soloIndex);
       expect(getAllContentIds(selection).has("team-only-item")).toBe(false);
@@ -825,6 +825,48 @@ describe("content/index", () => {
 
       const selection = resolveSelection(preset, "brownfield", "team", langIndex, undefined, []);
       expect(getAllContentIds(selection).has("ts-rule-empty")).toBe(true);
+    });
+
+    // ── Full preset opt-in: bypasses preference-based team-size narrowing ──
+
+    it("full preset + solo keeps team-only items (regression: board and onboard commands)", () => {
+      const preset = getPreset("full");
+      const selection = resolveSelection(preset, "brownfield", "solo", index);
+      const allIds = getAllContentIds(selection);
+      // team-only has tags ["team"] — under the fix, full preset rescues it
+      expect(allIds.has("team-only")).toBe(true);
+    });
+
+    it("full preset + solo keeps board+team items", () => {
+      const preset = getPreset("full");
+      const selection = resolveSelection(preset, "brownfield", "solo", index);
+      const allIds = getAllContentIds(selection);
+      // board-cmd has tags ["board", "team"] — under the fix, full preset rescues it
+      expect(allIds.has("board-cmd")).toBe(true);
+    });
+
+    it("full preset + greenfield + solo still removes brownfield-only items", () => {
+      const preset = getPreset("full");
+      const selection = resolveSelection(preset, "greenfield", "solo", index);
+      const allIds = getAllContentIds(selection);
+      // projectType filter is a technical compatibility filter and still applies under full
+      expect(allIds.has("bf-cmd")).toBe(false);
+    });
+
+    it("standard preset + solo still removes team-only items (scope check: fix is full-only)", () => {
+      const preset = getPreset("standard");
+      const selection = resolveSelection(preset, "brownfield", "solo", index);
+      const allIds = getAllContentIds(selection);
+      // standard + solo should still filter team-only items — fix is scoped to full
+      expect(allIds.has("team-only")).toBe(false);
+    });
+
+    it("full preset + solo with skipContextFilters=true keeps team items (config.ts path unchanged)", () => {
+      const preset = getPreset("full");
+      const selection = resolveSelection(preset, "brownfield", "solo", index, undefined, undefined, { skipContextFilters: true });
+      const allIds = getAllContentIds(selection);
+      expect(allIds.has("team-only")).toBe(true);
+      expect(allIds.has("board-cmd")).toBe(true);
     });
   });
 

--- a/src/__tests__/fixtures/agents/agents/modes/fake-mode.md
+++ b/src/__tests__/fixtures/agents/agents/modes/fake-mode.md
@@ -1,0 +1,8 @@
+---
+id: fake-mode
+type: mode
+description: Subdirectory mode fixture — filter must exclude from agent pickers.
+---
+# Fake Mode
+
+Companion behavioural mode. Not a standalone user-invocable agent.

--- a/src/__tests__/fixtures/agents/agents/shared/fake-reference.md
+++ b/src/__tests__/fixtures/agents/agents/shared/fake-reference.md
@@ -1,0 +1,8 @@
+---
+id: fake-reference
+type: reference
+description: Subdirectory shared-reference fixture — filter must exclude from agent pickers.
+---
+# Fake Reference
+
+Cross-cutting reference content. Not a standalone user-invocable agent.

--- a/src/__tests__/fixtures/agents/commands/board/pickup-fake.md
+++ b/src/__tests__/fixtures/agents/commands/board/pickup-fake.md
@@ -1,0 +1,8 @@
+---
+id: pickup-fake
+type: command
+description: Subdirectory sub-workflow command fixture — filter must exclude from command pickers.
+---
+# Pickup Fake
+
+Workflow step invoked by a parent command. Not a standalone user-invocable command.

--- a/src/__tests__/fixtures/agents/commands/hatch3r-fake-shared.md
+++ b/src/__tests__/fixtures/agents/commands/hatch3r-fake-shared.md
@@ -1,0 +1,8 @@
+---
+id: hatch3r-fake-shared
+type: shared-context
+description: Top-level shared-context fixture — filter must exclude by frontmatter type even though path is at top level.
+---
+# Fake Shared
+
+Top-level companion content that must be filtered out by frontmatter type.

--- a/src/__tests__/manifest/hatchJson.test.ts
+++ b/src/__tests__/manifest/hatchJson.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { createManifest, addManagedFile, removeManagedFile, migrateManifest, readManifest, writeManifest } from "../../manifest/hatchJson.js";
 import { HatchError } from "../../types.js";
+import { HATCH3R_VERSION } from "../../version.js";
 
 describe("hatchJson", () => {
   describe("createManifest", () => {
@@ -12,7 +13,7 @@ describe("hatchJson", () => {
         tools: ["cursor"],
       });
       expect(manifest.version).toBe("2.0.0");
-      expect(manifest.hatch3rVersion).toBe("1.6.2");
+      expect(manifest.hatch3rVersion).toBe(HATCH3R_VERSION);
       expect(manifest.platform).toBe("github");
       expect(manifest.tools).toEqual(["cursor"]);
       expect(manifest.features.agents).toBe(true);

--- a/src/__tests__/manifest/hatchJson.test.ts
+++ b/src/__tests__/manifest/hatchJson.test.ts
@@ -12,7 +12,7 @@ describe("hatchJson", () => {
         tools: ["cursor"],
       });
       expect(manifest.version).toBe("2.0.0");
-      expect(manifest.hatch3rVersion).toBe("1.6.1");
+      expect(manifest.hatch3rVersion).toBe("1.6.2");
       expect(manifest.platform).toBe("github");
       expect(manifest.tools).toEqual(["cursor"]);
       expect(manifest.features.agents).toBe(true);

--- a/src/__tests__/manifest/hatchJson.test.ts
+++ b/src/__tests__/manifest/hatchJson.test.ts
@@ -12,7 +12,7 @@ describe("hatchJson", () => {
         tools: ["cursor"],
       });
       expect(manifest.version).toBe("2.0.0");
-      expect(manifest.hatch3rVersion).toBe("1.6.0");
+      expect(manifest.hatch3rVersion).toBe("1.6.1");
       expect(manifest.platform).toBe("github");
       expect(manifest.tools).toEqual(["cursor"]);
       expect(manifest.features.agents).toBe(true);

--- a/src/__tests__/pipeline/agentToolAllowlist.test.ts
+++ b/src/__tests__/pipeline/agentToolAllowlist.test.ts
@@ -378,10 +378,10 @@ describe("agentToolAllowlist", () => {
       checkToolAccess("unknown-agent", "read", (e) => events.push(e));
       const entry = toFailureLogEntry(events[0], {
         correlationId: "run-123",
-        version: "1.6.0",
+        version: "1.6.1",
       });
       expect(entry.correlationId).toBe("run-123");
-      expect(entry.version).toBe("1.6.0");
+      expect(entry.version).toBe("1.6.1");
     });
 
     it("produces an entry that round-trips through formatLogEntry + parseFailureLog", () => {

--- a/src/adapters/agentsmd.ts
+++ b/src/adapters/agentsmd.ts
@@ -34,7 +34,7 @@ export class AgentsMdAdapter extends BaseAdapter {
 
     // Agents section
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/amazonq.ts
+++ b/src/adapters/amazonq.ts
@@ -2,7 +2,6 @@ import type { AdapterOutput } from "../types.js";
 import { toPrefixedId } from "../types.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { BaseAdapter, output, type AdapterContext } from "./base.js";
-import { readCanonicalFiles } from "./canonical.js";
 import { applyCustomization } from "./customization.js";
 import type { HookEvent } from "../hooks/types.js";
 
@@ -80,7 +79,7 @@ export class AmazonQAdapter extends BaseAdapter {
     // Generate native Amazon Q custom agent descriptors in .amazonq/cli-agents/.
     // Each canonical agent maps to a JSON descriptor that Amazon Q discovers natively.
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,4 +1,4 @@
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   AdapterOutput,
   CanonicalFile,
@@ -9,7 +9,7 @@ import type {
 import { resolveAgentModel } from "../models/resolve.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { generateBridgeOrchestration } from "../cli/shared/agentsContent.js";
-import { readCanonicalFiles, sortByPrecedence, type CanonicalType } from "./canonical.js";
+import { filterUserFacing, readCanonicalFiles, sortByPrecedence, type CanonicalType } from "./canonical.js";
 import { applyCustomization, applyCustomizationRaw } from "./customization.js";
 import { readMcpConfig, transformEnvVarSyntax, type McpServerEntry } from "./mcp-utils.js";
 import { readHookDefinitions } from "../hooks/index.js";
@@ -173,6 +173,31 @@ export abstract class BaseAdapter implements Adapter {
     return files;
   }
 
+  /**
+   * Read canonical commands or agents and filter to only those that should
+   * appear in a tool's user-facing command/agent picker. Wraps
+   * {@link readCanonicalFiles} + {@link filterUserFacing} and applies
+   * provenance tracking only to the surviving files, so filtered-out
+   * companion content does not pollute the adapter's source-file manifest.
+   *
+   * Filter rules are documented on {@link filterUserFacing}: files in
+   * support subdirectories (`commands/board/`, `agents/modes/`, etc.) and
+   * top-level files with a non-primary frontmatter `type:` (e.g.
+   * `shared-context`, `reference`, `mode`) are excluded.
+   */
+  protected async readUserFacingCanonicalFiles(
+    agentsDir: string,
+    type: "commands" | "agents",
+  ): Promise<CanonicalFile[]> {
+    const files = await readCanonicalFiles(agentsDir, type, this.warnings);
+    const expectedType = type === "commands" ? "command" : "agent";
+    const filtered = filterUserFacing(files, expectedType, join(agentsDir, type));
+    for (const f of filtered) {
+      if (f.sourcePath) this._trackedSourceFiles.add(f.sourcePath);
+    }
+    return filtered;
+  }
+
   protected abstract doGenerate(ctx: AdapterContext): Promise<AdapterOutput[]>;
 
   /**
@@ -243,7 +268,7 @@ export abstract class BaseAdapter implements Adapter {
   ): Promise<string[]> {
     if (!ctx.features.agents) return [];
     const lines: string[] = [];
-    const agents = await this.readTrackedCanonicalFiles(ctx.agentsDir, "agents");
+    const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
     const minimal = this.isMinimal(ctx);
     for (const agent of agents) {
       const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
@@ -308,7 +333,10 @@ export abstract class BaseAdapter implements Adapter {
   ): Promise<AdapterOutput[]> {
     if (!ctx.features.commands) return [];
     const results: AdapterOutput[] = [];
-    const commands = await this.readTrackedCanonicalFiles(ctx.agentsDir, "commands");
+    // Filter out companion/reference content (shared-context, subdirectory
+    // workflow steps like commands/board/pickup-*) so they do not appear
+    // as user-invocable entries in the tool's command picker.
+    const commands = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "commands");
     for (const cmd of commands) {
       const { content, skip, warnings } = await applyCustomizationRaw(ctx.projectRoot, cmd);
       this.warnings.push(...warnings);

--- a/src/adapters/canonical.ts
+++ b/src/adapters/canonical.ts
@@ -52,6 +52,44 @@ export function sortByPrecedence<T extends { precedence?: string; id: string }>(
   });
 }
 
+/**
+ * Filter canonical files down to those that should appear as user-invocable
+ * entries in a tool's command/agent picker (e.g. `.claude/commands/`,
+ * `.cursor/commands/`, `.claude/agents/`).
+ *
+ * Two orthogonal signals combined with AND:
+ * 1. Top-level-only: the file's path relative to `baseDir` must not contain
+ *    a path separator. This excludes companion subdirectories such as
+ *    `commands/board/`, `commands/revision/`, `agents/modes/`, and
+ *    `agents/shared/` whose contents are sub-workflows or shared reference
+ *    material invoked by parent commands/agents, not directly by users.
+ * 2. Frontmatter-type whitelist: `frontmatterType` must be either absent
+ *    (legacy files lacking the field load unchanged) or equal to
+ *    `expectedFrontmatterType`. This catches the rare case of a top-level
+ *    companion file such as `commands/hatch3r-board-shared.md`
+ *    (`type: shared-context`) that sits next to the real commands but must
+ *    not be invocable.
+ *
+ * Canonical `.agents/` content (populated by `src/content/index.ts`)
+ * remains unfiltered, so parent commands can continue referencing
+ * companion files by name — this helper only gates per-tool adapter
+ * emission.
+ */
+export function filterUserFacing(
+  files: CanonicalFile[],
+  expectedFrontmatterType: "command" | "agent",
+  baseDir: string,
+): CanonicalFile[] {
+  const normalizedBase = baseDir.endsWith("/") ? baseDir : `${baseDir}/`;
+  return files.filter((file) => {
+    if (!file.sourcePath.startsWith(normalizedBase)) return true;
+    const relative = file.sourcePath.slice(normalizedBase.length);
+    if (relative.includes("/")) return false;
+    if (file.frontmatterType && file.frontmatterType !== expectedFrontmatterType) return false;
+    return true;
+  });
+}
+
 const FRONTMATTER_REGEX = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n([\s\S]*))?$/;
 
 /**
@@ -189,6 +227,14 @@ export function parseFrontmatter(
 ): {
   metadata: CanonicalMetadata;
   content: string;
+  /**
+   * The author-declared `type:` value from frontmatter, or `undefined` when
+   * the field is absent or was a non-string. Distinct from `metadata.type`,
+   * which falls back to `"rule"` when absent — callers that need to
+   * distinguish "user declared type" from "parser default" (e.g. the
+   * adapter filter at {@link filterUserFacing}) should read this field.
+   */
+  rawType?: string;
 } {
   const match = rawContent.match(FRONTMATTER_REGEX);
   if (!match) {
@@ -205,6 +251,7 @@ export function parseFrontmatter(
     type: "rule",
     description: "",
   };
+  let rawType: string | undefined;
 
   if (parsed && typeof parsed === "object") {
     // C7.5-W2B2-H8: enforce type contract on security-relevant identity
@@ -218,6 +265,7 @@ export function parseFrontmatter(
       if (raw === undefined) continue;
       if (typeof raw === "string") {
         metadata[field] = raw;
+        if (field === "type") rawType = raw;
       } else if (typeMismatches) {
         typeMismatches.push(
           `${field} field must be a string, got ${describeYamlType(raw)} (value: ${JSON.stringify(raw)})`,
@@ -261,7 +309,7 @@ export function parseFrontmatter(
   metadata.type = metadata.type ?? "rule";
   metadata.description = metadata.description ?? "";
 
-  return { metadata, content: content ?? "" };
+  return { metadata, content: content ?? "", rawType };
 }
 
 /**
@@ -363,11 +411,19 @@ async function readSingleMd(
     return errorResult;
   }
 
-  const { metadata, content } = parsed;
+  const { metadata, content, rawType } = parsed;
   const id = metadata.id || metadata.name || fallbackId;
   const canonical: CanonicalFile = {
     id,
     type: fileType,
+    // Preserve the author-declared frontmatter `type` alongside the reader
+    // bucket so downstream filters (see `filterUserFacing`) can distinguish
+    // user-invocable commands/agents from companion content
+    // (`shared-context`, `reference`, `mode`) within the same directory.
+    // `rawType` is undefined when the author omitted `type:`, so files
+    // without an explicit declaration fall through the filter's
+    // back-compat path and are kept.
+    frontmatterType: rawType,
     description: metadata.description ?? "",
     scope: metadata.scope,
     model: metadata.model,

--- a/src/adapters/canonical.ts
+++ b/src/adapters/canonical.ts
@@ -1,5 +1,5 @@
 import { readFile, readdir, lstat } from "node:fs/promises";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { parse as parseYaml } from "yaml";
 import type { CanonicalFile, CanonicalMetadata, RulePrecedence } from "../types.js";
 import { sanitizePipelineInput } from "../pipeline/promptGuard.js";
@@ -74,17 +74,33 @@ export function sortByPrecedence<T extends { precedence?: string; id: string }>(
  * remains unfiltered, so parent commands can continue referencing
  * companion files by name — this helper only gates per-tool adapter
  * emission.
+ *
+ * Cross-platform: uses `path.relative` to normalise the pair of absolute
+ * paths before the subdirectory check, because on Windows `sourcePath` and
+ * `baseDir` arrive backslash-separated (from `node:path.join` / `readdir`).
+ * The relative-path check then looks for either separator so mixed inputs
+ * (POSIX paths synthesised in tests, Windows paths emitted by `readdir`)
+ * all land on the same outcome.
  */
 export function filterUserFacing(
   files: CanonicalFile[],
   expectedFrontmatterType: "command" | "agent",
   baseDir: string,
 ): CanonicalFile[] {
-  const normalizedBase = baseDir.endsWith("/") ? baseDir : `${baseDir}/`;
   return files.filter((file) => {
-    if (!file.sourcePath.startsWith(normalizedBase)) return true;
-    const relative = file.sourcePath.slice(normalizedBase.length);
-    if (relative.includes("/")) return false;
+    const rel = relative(baseDir, file.sourcePath);
+    // Safe default when `sourcePath` lies outside `baseDir`: `path.relative`
+    // returns a `..`-prefixed path (or a cross-drive absolute path on
+    // Windows). Keep the file — filtering is a picker-visibility concern,
+    // not a scoping guard.
+    if (rel === "" || rel.startsWith("..")) return true;
+    // Windows cross-drive absolute: path.relative returns the second path
+    // verbatim when it cannot express a relative traversal.
+    if (/^[A-Za-z]:[\\/]/.test(rel)) return true;
+    // Subdirectory check: accept either separator because tests may feed
+    // POSIX-style paths through on Windows, and `readdir` on Windows
+    // returns native backslashes.
+    if (rel.includes("/") || rel.includes("\\")) return false;
     if (file.frontmatterType && file.frontmatterType !== expectedFrontmatterType) return false;
     return true;
   });

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -279,7 +279,7 @@ export class ClaudeAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/cline.ts
+++ b/src/adapters/cline.ts
@@ -25,7 +25,7 @@ export class ClineAdapter extends BaseAdapter {
 
     const customModes: ClineCustomMode[] = [];
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -80,7 +80,7 @@ export class CodexAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -107,7 +107,7 @@ jobs:
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -65,7 +65,7 @@ export class CursorAdapter extends BaseAdapter {
     }
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,8 +1,9 @@
+import { join } from "node:path";
 import type { AdapterOutput } from "../types.js";
 import { toPrefixedId } from "../types.js";
 import { wrapInManagedBlock } from "../merge/managedBlocks.js";
 import { BaseAdapter, output, type AdapterContext } from "./base.js";
-import { readCanonicalFiles } from "./canonical.js";
+import { filterUserFacing, readCanonicalFiles } from "./canonical.js";
 import { applyCustomization } from "./customization.js";
 import type { HookEvent } from "../hooks/types.js";
 import { escapeTomlString } from "./toml-utils.js";
@@ -76,7 +77,8 @@ export class GeminiAdapter extends BaseAdapter {
     );
 
     if (ctx.features.commands) {
-      const commands = await readCanonicalFiles(ctx.agentsDir, "commands", this.warnings);
+      const commandsRaw = await readCanonicalFiles(ctx.agentsDir, "commands", this.warnings);
+      const commands = filterUserFacing(commandsRaw, "command", join(ctx.agentsDir, "commands"));
       for (const cmd of commands) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, cmd);
         this.warnings.push(...warnings);

--- a/src/adapters/goose.ts
+++ b/src/adapters/goose.ts
@@ -39,7 +39,7 @@ export class GooseAdapter extends BaseAdapter {
     // #123: Read agents once and reuse for both inline content and profile generation
     // to avoid double readCanonicalFiles + double applyCustomization.
     const agents = ctx.features.agents
-      ? await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings)
+      ? await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents")
       : [];
 
     const lines = [

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -104,7 +104,7 @@ export class OpenCodeAdapter extends BaseAdapter {
     results.push(output("opencode.json", JSON.stringify(opencodeConfig, null, 2)));
 
     if (ctx.features.agents) {
-      const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+      const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
       for (const agent of agents) {
         const { content, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, agent);
         this.warnings.push(...warnings);

--- a/src/adapters/windsurf.ts
+++ b/src/adapters/windsurf.ts
@@ -59,7 +59,7 @@ export class WindsurfAdapter extends BaseAdapter {
    */
   private async windsurfAgentToolPolicies(ctx: AdapterContext): Promise<string[]> {
     if (!ctx.features.agents) return [];
-    const agents = await readCanonicalFiles(ctx.agentsDir, "agents", this.warnings);
+    const agents = await this.readUserFacingCanonicalFiles(ctx.agentsDir, "agents");
     const rows: string[] = [];
     for (const agent of agents) {
       const { skip } = await applyCustomization(ctx.projectRoot, agent);

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -27,6 +27,7 @@ interface CapturedConfig {
   features: Features;
   mcpServers: string[];
   contentSelection: ContentSelection;
+  worktreeEnabled: boolean;
 }
 
 function captureConfig(manifest: NonNullable<CleanInventory["manifest"]>): CapturedConfig {
@@ -46,6 +47,7 @@ function captureConfig(manifest: NonNullable<CleanInventory["manifest"]>): Captu
       teamSize: "solo",
       items: { agents: [], skills: [], rules: [], commands: [], prompts: [], hooks: [], githubAgents: [] },
     },
+    worktreeEnabled: manifest.worktree?.enabled ?? false,
   };
 }
 
@@ -224,6 +226,7 @@ export async function cleanCommand(
           mcpServers: config.mcpServers,
           repoInfo,
           contentSelection: config.contentSelection,
+          worktreeEnabled: config.worktreeEnabled,
         };
 
         await runInit(initOpts);

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -163,6 +163,7 @@ export interface RunInitOptions {
   mcpServers: string[];
   repoInfo: RepoInfo;
   contentSelection: ContentSelection;
+  worktreeEnabled: boolean;
 }
 
 // C8-D1-M3: Guard against a double `runInit` on the same target directory.
@@ -195,7 +196,7 @@ export async function runInit(options: RunInitOptions): Promise<void> {
 }
 
 async function runInitInner(options: RunInitOptions): Promise<void> {
-  const { rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection } = options;
+  const { rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection, worktreeEnabled } = options;
   const agentsDir = join(rootDir, AGENTS_DIR);
   const totalSteps = 4;
 
@@ -273,7 +274,7 @@ async function runInitInner(options: RunInitOptions): Promise<void> {
   // never reached disk if all adapters fail (line 215 throw below).
   const s2 = createSpinner(step(2, totalSteps, "Preparing manifest..."));
   s2.start();
-  const manifest = createManifest({ platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, content: contentSelection, languages: repoInfo.languages });
+  const manifest = createManifest({ platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, content: contentSelection, languages: repoInfo.languages, worktreeEnabled });
   s2.succeed(step(2, totalSteps, "Manifest prepared"));
 
   const s3 = createSpinner(
@@ -337,11 +338,9 @@ async function runInitInner(options: RunInitOptions): Promise<void> {
     }
   }
 
-  // Generate .worktreeinclude for worktree-capable tools
-  const hasWorktreeTool = tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
-  if (hasWorktreeTool) {
-    manifest.worktree = manifest.worktree ?? { enabled: true };
-  }
+  // Generate .worktreeinclude when manifest.worktree.enabled is true.
+  // createManifest sets this based on the worktreeEnabled option (honored when
+  // defined) or auto-detection of worktree-capable tools (back-compat fallback).
   if (manifest.worktree?.enabled) {
     const wtContent = await generateWorktreeInclude(manifest, rootDir);
     const wtManaged = extractManagedContent(wtContent);
@@ -480,6 +479,7 @@ export async function initCommand(
     projectType?: string;
     teamSize?: string;
     workspace?: boolean;
+    worktree?: boolean;
     quick?: boolean;
     default?: boolean;
   } = {},
@@ -585,6 +585,10 @@ export async function initCommand(
       tools = DEFAULT_TOOLS;
     }
 
+    // Worktree: honor explicit --worktree/--no-worktree, else auto-enable for
+    // worktree-capable tools (preserves pre-1.6.1 --yes behavior for CI callers).
+    const worktreeEnabled = opts.worktree ?? tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
+
     const features = { ...DEFAULT_FEATURES };
     const platformMcp = PLATFORM_MCP_SERVER[platform];
     const mcpServers = features.mcp
@@ -613,7 +617,7 @@ export async function initCommand(
     warnBoardPrerequisites(contentSelection);
 
     await checkExisting(rootDir, true, contentSelection);
-    await runInit({ rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection });
+    await runInit({ rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection, worktreeEnabled });
     return;
   }
 
@@ -794,6 +798,25 @@ export async function initCommand(
   ]);
   const tools = toolAnswers.tools.length > 0 ? toolAnswers.tools : DEFAULT_TOOLS;
 
+  // Worktree file isolation: mirrors config.ts prompt. Honor explicit
+  // --worktree/--no-worktree flag. Else prompt when a worktree-capable tool
+  // is selected, else disable. Prompt order: tools -> worktree -> features.
+  const hasWorktreeTool = tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
+  let worktreeEnabled: boolean;
+  if (opts.worktree !== undefined) {
+    worktreeEnabled = opts.worktree;
+  } else if (hasWorktreeTool) {
+    const wtAnswer = await inquirer.prompt<{ enabled: boolean }>([{
+      type: "confirm",
+      name: "enabled",
+      message: "Enable worktree file isolation (for parallel agent sessions)?",
+      default: true,
+    }]);
+    worktreeEnabled = wtAnswer.enabled;
+  } else {
+    worktreeEnabled = false;
+  }
+
   // #143 (D19-14): Streamline MCP onboarding — surface secret notes inline
   const secretNotes = tools.map((t) => TOOL_SECRET_NOTES[t]).filter(Boolean);
   if (secretNotes.length > 0) {
@@ -851,7 +874,7 @@ export async function initCommand(
   warnBoardPrerequisites(contentSelection);
 
   await checkExisting(rootDir, false, contentSelection);
-  await runInit({ rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection });
+  await runInit({ rootDir, platform, owner, repo, namespace, project, defaultBranch, tools, features, mcpServers, repoInfo, contentSelection, worktreeEnabled });
 }
 
 // ── Workspace initialization ──────────────────────────────────────
@@ -860,7 +883,7 @@ async function runWorkspaceInit(
   rootDir: string,
   detectedRepos: Awaited<ReturnType<typeof detectSubRepos>>,
   repoInfo: RepoInfo,
-  opts: { tools?: string; yes?: boolean; preset?: string; projectType?: string; teamSize?: string },
+  opts: { tools?: string; yes?: boolean; preset?: string; projectType?: string; teamSize?: string; worktree?: boolean },
 ): Promise<void> {
   const headless = !!opts.yes;
 
@@ -963,9 +986,13 @@ async function runWorkspaceInit(
   let features: Features;
   let mcpServers: string[];
   let contentSelection: ContentSelection;
+  let worktreeEnabled: boolean;
 
   if (headless) {
     tools = resolveToolsFromOpts(opts.tools, repoInfo);
+    // Worktree: honor explicit --worktree/--no-worktree, else auto-enable for
+    // worktree-capable tools (preserves pre-1.6.1 --yes behavior).
+    worktreeEnabled = opts.worktree ?? tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
     features = { ...DEFAULT_FEATURES };
     const platformMcp = PLATFORM_MCP_SERVER[platform];
     mcpServers = features.mcp
@@ -1082,6 +1109,24 @@ async function runWorkspaceInit(
     ]);
     tools = toolAnswers.tools.length > 0 ? toolAnswers.tools : DEFAULT_TOOLS;
 
+    // Worktree file isolation: mirrors config.ts prompt. Honor explicit
+    // --worktree/--no-worktree flag. Else prompt when a worktree-capable tool
+    // is selected, else disable.
+    const wsHasWorktreeTool = tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
+    if (opts.worktree !== undefined) {
+      worktreeEnabled = opts.worktree;
+    } else if (wsHasWorktreeTool) {
+      const wsWtAnswer = await inquirer.prompt<{ enabled: boolean }>([{
+        type: "confirm",
+        name: "enabled",
+        message: "Enable worktree file isolation (for parallel agent sessions)?",
+        default: true,
+      }]);
+      worktreeEnabled = wsWtAnswer.enabled;
+    } else {
+      worktreeEnabled = false;
+    }
+
     // Surface per-editor secret loading notes
     const wsSecretNotes = tools.map((t) => TOOL_SECRET_NOTES[t]).filter(Boolean);
     if (wsSecretNotes.length > 0) {
@@ -1153,6 +1198,7 @@ async function runWorkspaceInit(
     mcpServers,
     repoInfo,
     contentSelection,
+    worktreeEnabled,
   });
 
   // Step 7: Build repo entries and select which to sync

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -55,6 +55,8 @@ export function createProgram(): Command {
     .option("--preset <preset>", "Content preset: minimal, standard, full (default: full)")
     .option("--project-type <type>", "Project type: greenfield, brownfield")
     .option("--team-size <size>", "Team size: solo, team")
+    .option("--worktree", "Enable git worktree file isolation (overrides tool auto-detect)")
+    .option("--no-worktree", "Disable git worktree file isolation")
     .option("--workspace", "Initialize as a multi-repo workspace")
     .action(initCommand);
 

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -356,7 +356,10 @@ export const TYPE_TO_SELECTION_KEY: Record<string, keyof ContentSelection["items
  * 3. If preset has excludeTags, remove items matching ANY of those tags
  * 4. If projectType is "greenfield", remove items tagged ONLY with "brownfield"
  * 5. If projectType is "brownfield", remove items tagged ONLY with "greenfield"
- * 6. If teamSize is "solo", remove items whose ONLY tags are "team" / "board"
+ * 6. If teamSize is "solo" AND preset.id !== "full", remove items whose ONLY tags are "team" / "board".
+ *    The "full" preset is an explicit opt-in that disables this preference-based narrowing; the
+ *    projectType filter and language filter still apply under full (they are technical
+ *    compatibility filters, not preferences).
  * 7. Items with protected: true are always included
  * 8. For "custom" preset, use customSelections as explicit ID list
  * 9. Language filtering (Finding #71): items with language tags (lang:*) are only
@@ -430,7 +433,10 @@ export function resolveSelection(
       }
 
       // Context filtering: team size
-      if (teamSize === "solo") {
+      // "full" preset is an explicit opt-in that bypasses preference-based narrowing.
+      // projectType and language filters remain active even under full — they are
+      // technical compatibility filters, not preferences.
+      if (teamSize === "solo" && preset.id !== "full") {
         // Remove items whose tags are exclusively team/board (no other workflow/domain tags)
         selected = selected.filter((item) => {
           if (item.protected) return true;
@@ -533,6 +539,11 @@ export function countProjectTypeExclusions(
 
 /**
  * Count how many items the team size filter would remove from a pre-filtered set.
+ *
+ * Preset-unaware approximation: the "full" preset rescues all such items at selection
+ * time (see resolveSelection), but this helper has no visibility into preset choice
+ * because callers use it for pre-prompt UX hints before the preset is known. Treat
+ * the returned count as an upper bound.
  */
 export function countTeamSizeExclusions(
   teamSize: "solo" | "team",

--- a/src/manifest/hatchJson.ts
+++ b/src/manifest/hatchJson.ts
@@ -78,6 +78,7 @@ export function createManifest(options: {
   mcpServers?: string[];
   content?: ContentSelection;
   languages?: string[];
+  worktreeEnabled?: boolean;
 }): HatchManifest {
   const platform = options.platform ?? "github";
   const owner = options.owner ?? "";
@@ -106,7 +107,9 @@ export function createManifest(options: {
   if (options.defaultBranch) {
     manifest.board = createMinimalBoardConfig(owner, repo, options.defaultBranch);
   }
-  if (options.tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t))) {
+  const autoEnable = options.tools.some(t => WORKTREE_CAPABLE_TOOLS.has(t));
+  const shouldEnable = options.worktreeEnabled ?? autoEnable;
+  if (shouldEnable) {
     manifest.worktree = { enabled: true };
   }
   return manifest;

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,16 @@ export type RulePrecedence = "critical" | "high" | "normal" | "low";
 export interface CanonicalFile {
   id: string;
   type: "rule" | "agent" | "skill" | "command" | "prompt" | "github-agent" | "hook" | "check" | "policy" | "learning";
+  /**
+   * Raw frontmatter `type:` value as declared by the author. Distinct from
+   * `type` above, which is the reader-category bucket set from the directory
+   * the file lives in. Used by adapter emission filters (see
+   * `filterUserFacing` in `src/adapters/canonical.ts`) to distinguish
+   * user-invocable commands/agents from companion content like
+   * `shared-context`, `reference`, and `mode` that lives in the same
+   * directory tree but must not appear in tool command/agent pickers.
+   */
+  frontmatterType?: string;
   description: string;
   scope?: string;
   model?: string;


### PR DESCRIPTION
## Summary

Release v1.6.2 bundles the work originally split across the v1.6.1 branch (PR #59 — now closed after the branch rename consolidation) and the subsequent UX fix for companion-content visibility (PR #60 — merged into this branch).

### 1. `full` preset now actually installs everything (ex-1.6.1)

The default `hatch3r init` profile silently dropped the 6 `hatch3r-board-*` commands (pickup, groom, refresh, init, fill, shared) and `hatch3r-onboard` because the solo team-size filter ran unconditionally over the resolved selection, even when the user's chosen preset explicitly promised "Everything including board management". The filter now scopes to non-`full` presets — users who opt into `full` receive the full catalog regardless of `teamSize`. Project-type and language filters continue to apply (they are technical compatibility filters, not preferences). Fix: `src/content/index.ts::resolveSelection` guard at line 436.

### 2. Worktree support now explicitly configurable in `init` (ex-1.6.1)

Previously `hatch3r init` auto-enabled worktree file isolation without prompting whenever a worktree-capable tool (currently `claude`) was selected, while `hatch3r config` did prompt — an asymmetric UX that hid a side-effect from interactive users. Init now mirrors the config prompt after tools selection and adds `--worktree` / `--no-worktree` CLI flags for headless callers. `--yes` without the flag preserves today's auto-enable behavior for CI compatibility. Fix: `src/cli/commands/init.ts` interactive and workspace branches; `src/cli/program.ts` flag registration; `src/manifest/hatchJson.ts::createManifest` honors explicit `worktreeEnabled` option. `src/cli/commands/clean.ts` reinit path threaded through the new option to keep `RunInitOptions` consistent.

### 3. Companion content no longer clutters the tool command/agent picker (ex-1.6.2)

`hatch3r init` / `hatch3r sync` previously emitted every `.md` file under `commands/` and `agents/` as a user-invocable entry in each tool's picker — including ~40 companion files (5 `type: shared-context`, 20 `agents/modes/*` with `type: mode`, 4 `agents/shared/*` with `type: reference`, 11 sub-workflow files under `commands/board/pickup-*` and `commands/revision/*`) that exist only to be referenced by parent commands/agents, not invoked directly. The recursive `readGlobMd()` (`src/adapters/canonical.ts:460`) still reads the full tree so cross-references continue to resolve, but a new `filterUserFacing()` helper gates per-adapter emission on two signals: the file's path relative to its content-type baseDir must have no subdirectory separator, **and** its frontmatter `type:` must match the reader bucket (`command` / `agent`) or be absent. Applied to `processCommandsRaw` and a new `readUserFacingCanonicalFiles` wrapper in `src/adapters/base.ts`, plus direct call sites in `gemini.ts` and each of the 10 agent-emitting adapters (claude, cursor, copilot, opencode, codex, amazonq, goose, windsurf, cline, agentsmd). `parseFrontmatter()` now returns `rawType?: string` so the filter distinguishes an author-declared `type:` from the parser's `"rule"` default. The `.agents/` canonical mirror is unchanged, so parent commands that read shared context by name keep working.

## Tests

- **ex-1.6.1**: 3 existing `resolveSelection` tests updated; 5 new tests cover `full + solo` behaviour; 5 new `init.test.ts` cases cover worktree prompt paths; 13 existing interactive init tests updated to queue the new prompt. Test count 2,594 → 2,604.
- **ex-1.6.2**: 7 new unit tests for `filterUserFacing` (top-level pass, subdirectory drop, frontmatter-type whitelist, both-signals-AND for agents, legacy back-compat, safe default outside baseDir, trailing-slash tolerance); 2 new adapter-level filter tests (claude, gemini); 4 new fixture files. 2 existing `readCanonicalFiles` tests adjusted. 9 hardcoded `"1.6.1"` version strings in 5 test files bumped to `"1.6.2"`. Test count 2,604 → 2,613.

## Test plan

- [x] `npm test` — 2,613 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (135 pre-existing warnings)
- [x] `npm run build` — success
- [x] `npm run inventory` — count probes pass at 1.6.2
- [ ] Manual smoke: `npx hatch3r init` with `--tools claude,cursor,gemini` against a scratch repo; confirm `.claude/commands/`, `.cursor/commands/`, `.gemini/commands/`, and `.claude/agents/` contain only top-level primary files and that `full` preset keeps `hatch3r-board-*` + `hatch3r-onboard` under `solo` teamSize.

## Branch history note

This PR supersedes the closed PRs #59 (release/1.6.1 → main) and #60 (release/1.6.2 → release/1.6.1). The original release/1.6.1 branch was renamed to release/1.6.2 via the GitHub rename API to consolidate both releases under a single version banner; the pre-existing release/1.6.2 branch was deleted (its content was already merged into release/1.6.1 via PR #60). No commits were lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core content-selection and adapter-emission paths plus `init` CLI prompting/flags, so regressions could change what files get installed or generated across tools; changes are well-covered by new unit and adapter-level tests.
> 
> **Overview**
> **Improves init/sync output correctness and UX** by (1) making the `full` preset truly include team/board-only content even for `teamSize=solo` (while still applying projectType/language compatibility filters), and (2) making worktree isolation explicitly configurable during `hatch3r init` (interactive prompt + `--worktree/--no-worktree` flags) and threading that choice through manifest creation and re-init flows.
> 
> **Reduces noise in tool command/agent pickers** by introducing `filterUserFacing()` and a `CanonicalFile.frontmatterType` field (via `parseFrontmatter` exposing the author-declared `type`) so adapters emit only top-level user-invocable `command`/`agent` files, excluding subdirectory workflows and non-primary types like `shared-context`/`mode`/`reference`.
> 
> Also bumps version metadata to `1.6.2`, updates docs/inventory dates, and adds/updates tests + fixtures to cover the new selection, worktree, and filtering behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483a47b56edb24962cbb2277129eb6a4f6c3084f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->