### PR TITLE
fix: green + clean CI on post-privatization main (tests, CVE, coverage, inventory, Windows)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
+# Line-ending normalization (Windows CI fix).
+# Git auto-detects text vs binary, normalizes text to LF in the index, and
+# forces LF in the working tree on EVERY platform — including a Windows
+# checkout (which otherwise inherits core.autocrlf=true and writes CRLF).
+# Keeps tests that read committed files seeing LF, matching code that emits
+# LF, so the suite is deterministic across ubuntu/macos/windows.
+* text=auto eol=lf
+
+# Windows shell scripts must keep CRLF or they misbehave under cmd.exe.
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf
+
+# Generated lock workflows.
 .github/workflows/*.lock.yml linguist-generated=true merge=ours

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,13 @@ jobs:
 
   build:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    # Windows runners are I/O-slow and variable: the full suite (npm ci + build
+    # + ~4500 tests, no coverage) finishes in ~10 min on a fast windows-latest
+    # box, but slow-runner variance pushed node 22/24 past a flat 15-min ceiling
+    # (cancelled at 15m04s/15m11s) while node 26 finished in 9m43s on the SAME
+    # commit with every test passing. Give Windows headroom; keep the tight
+    # 15-min hang-guard for the fast OSes.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 25 || 15 }}
     strategy:
       fail-fast: false
       matrix:

--- a/governance/inventory.json
+++ b/governance/inventory.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-06-03",
+  "lastUpdated": "2026-06-04",
   "counts": {
     "adapters": 3,
     "agents": 29,

--- a/scripts/__tests__/check-cli-cves.test.ts
+++ b/scripts/__tests__/check-cli-cves.test.ts
@@ -1,0 +1,404 @@
+import { describe, expect, it } from "vitest";
+
+import type { CliToolMeta } from "../../src/cliTools/registry.js";
+import {
+  checkCliCves,
+  formatTextReport,
+  mapToolToOsvTarget,
+  normalizeSeverity,
+  parseCvssBase,
+  type CheckReport,
+  type OsvQueryResponse,
+  type OsvVulnerability,
+} from "../check-cli-cves.js";
+
+// ── Fixture helpers ────────────────────────────────────────────────
+
+const NOW = new Date("2026-06-03T00:00:00Z");
+
+/**
+ * Build a minimal CliToolMeta for tests. `id` is the load-bearing key (it
+ * drives ECOSYSTEM_OVERRIDES + SCAN_EXEMPT_TOOLS lookup); the rest are filler.
+ * Real ids ("docker", "rtk") are required to exercise the override/exempt
+ * tables — they are cast through CliToolMeta["id"] because the union is closed.
+ */
+function meta(id: string, overrides: Partial<CliToolMeta> = {}): CliToolMeta {
+  return {
+    id: id as CliToolMeta["id"],
+    probe: id,
+    description: `test ${id}`,
+    category: "search",
+    tier: 3,
+    install: {
+      mac: [{ manager: "brew", command: `brew install ${id}` }],
+      linux: [{ manager: "apt", command: `sudo apt install ${id}` }],
+      win: [{ manager: "scoop", command: `scoop install ${id}` }],
+    },
+    ...overrides,
+  } as CliToolMeta;
+}
+
+/** Build an OSV.dev-shaped vulnerability. */
+function vuln(overrides: Partial<OsvVulnerability> = {}): OsvVulnerability {
+  return {
+    id: "GHSA-xxxx-yyyy-zzzz",
+    summary: "Test advisory",
+    published: "2026-01-01T00:00:00Z",
+    database_specific: { severity: "HIGH" },
+    ...overrides,
+  };
+}
+
+/**
+ * Mock fetch that returns a queued response per call and records the request
+ * bodies so tests can assert which targets were (not) queried.
+ */
+function fakeFetcher(
+  perCall: Array<{ status?: number; body: OsvQueryResponse } | Error>,
+): { fetcher: typeof fetch; bodies: Array<Record<string, unknown>> } {
+  let i = 0;
+  const bodies: Array<Record<string, unknown>> = [];
+  const fetcher = (async (_url: string, init?: RequestInit) => {
+    if (init?.body) bodies.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+    const next = perCall[i++];
+    if (next === undefined) {
+      throw new Error("fakeFetcher: no more responses queued");
+    }
+    if (next instanceof Error) throw next;
+    const status = next.status ?? 200;
+    return new Response(JSON.stringify(next.body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetcher, bodies };
+}
+
+// ── mapToolToOsvTarget (Part 2 mappings) ──────────────────────────
+
+describe("mapToolToOsvTarget", () => {
+  it("maps the 6 newly-added tools to their OSV ecosystems", () => {
+    expect(mapToolToOsvTarget(meta("docker"))).toMatchObject({
+      ecosystem: "Go",
+      name: "github.com/moby/moby",
+    });
+    expect(mapToolToOsvTarget(meta("podman"))).toMatchObject({
+      ecosystem: "Go",
+      name: "github.com/containers/podman/v5",
+    });
+    expect(mapToolToOsvTarget(meta("mods"))).toMatchObject({
+      ecosystem: "Go",
+      name: "github.com/charmbracelet/mods",
+    });
+    expect(mapToolToOsvTarget(meta("miller"))).toMatchObject({
+      ecosystem: "Go",
+      name: "github.com/johnkerl/miller/v6",
+    });
+    expect(mapToolToOsvTarget(meta("container-use"))).toMatchObject({
+      ecosystem: "Go",
+      name: "github.com/dagger/container-use",
+    });
+    expect(mapToolToOsvTarget(meta("az-devops"))).toMatchObject({
+      ecosystem: "PyPI",
+      name: "azure-devops",
+    });
+  });
+
+  it("returns null for an unknown tool with no override", () => {
+    expect(mapToolToOsvTarget(meta("totally-unknown-tool"))).toBeNull();
+  });
+});
+
+// ── checkCliCves end-to-end ───────────────────────────────────────
+
+describe("checkCliCves", () => {
+  it("(1) a mapped tool with a clean OSV response yields no finding and a target", async () => {
+    const { fetcher } = fakeFetcher([{ body: { vulns: [] } }]);
+    const report = await checkCliCves({
+      registry: { docker: meta("docker", { minVersion: ">=29.5.2" }) },
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.targets).toHaveLength(1);
+    expect(report.targets[0]).toMatchObject({ tool: "docker", ecosystem: "Go" });
+    expect(report.findings).toHaveLength(0);
+    expect(report.unmapped).toHaveLength(0);
+    expect(report.exempted).toHaveLength(0);
+  });
+
+  it("(2) a scan-exempt tool lands in `exempted`, never in `unmapped`, and is never queried", async () => {
+    const { fetcher, bodies } = fakeFetcher([]);
+    const report = await checkCliCves({
+      registry: { rtk: meta("rtk", { tier: 3, category: "ai" }) },
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.exempted).toHaveLength(1);
+    expect(report.exempted[0].meta.id).toBe("rtk");
+    expect(report.exempted[0].reason).toMatch(/no OSV advisory package/i);
+    expect(report.unmapped).toHaveLength(0);
+    expect(report.targets).toHaveLength(0);
+    // The exempt tool must never be queried.
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("(2b) comby is also exempt and not queried even when mixed with a mapped tool", async () => {
+    const { fetcher, bodies } = fakeFetcher([{ body: { vulns: [] } }]);
+    const report = await checkCliCves({
+      registry: {
+        comby: meta("comby"),
+        docker: meta("docker"),
+      },
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.exempted.map((e) => e.meta.id)).toContain("comby");
+    expect(report.targets.map((t) => t.tool)).toEqual(["docker"]);
+    // Exactly one query — for docker only; comby was skipped.
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toMatchObject({
+      package: { name: "github.com/moby/moby", ecosystem: "Go" },
+    });
+  });
+
+  it("(3) an acknowledged Critical+stale advisory is a finding with acknowledged=true but absent from staleFindings", async () => {
+    const { fetcher } = fakeFetcher([
+      {
+        body: {
+          vulns: [
+            vuln({
+              id: "GHSA-g76p-4vg5-f4qh", // in ACKNOWLEDGED_ADVISORIES
+              published: "2026-01-01T00:00:00Z", // ~153 days before NOW -> stale
+              database_specific: { severity: "CRITICAL" },
+            }),
+          ],
+        },
+      },
+    ]);
+    const report = await checkCliCves({
+      registry: { llm: meta("llm", { category: "ai" }) },
+      maxAgeDays: 30,
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0].acknowledged).toBe(true);
+    expect(report.findings[0].isStale).toBe(true);
+    expect(report.findings[0].severity).toBe("CRITICAL");
+    // Gate-relevant set excludes the acknowledged advisory -> gate would pass.
+    expect(report.staleFindings).toHaveLength(0);
+    expect(report.acknowledgedFindings).toHaveLength(1);
+  });
+
+  it("(4) a non-acknowledged Critical+stale advisory is present in staleFindings (gate would fail)", async () => {
+    const { fetcher } = fakeFetcher([
+      {
+        body: {
+          vulns: [
+            vuln({
+              id: "GHSA-not-acknowledged",
+              published: "2026-01-01T00:00:00Z", // stale relative to NOW
+              database_specific: { severity: "CRITICAL" },
+            }),
+          ],
+        },
+      },
+    ]);
+    const report = await checkCliCves({
+      registry: { docker: meta("docker") },
+      maxAgeDays: 30,
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.findings).toHaveLength(1);
+    expect(report.findings[0].acknowledged).toBe(false);
+    expect(report.staleFindings).toHaveLength(1);
+    expect(report.staleFindings[0].id).toBe("GHSA-not-acknowledged");
+  });
+
+  it("(5) a tool with no override and not exempt lands in `unmapped`", async () => {
+    const { fetcher, bodies } = fakeFetcher([]);
+    const report = await checkCliCves({
+      registry: { "totally-unknown-tool": meta("totally-unknown-tool") },
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.unmapped).toHaveLength(1);
+    expect(report.unmapped[0].id).toBe("totally-unknown-tool");
+    expect(report.targets).toHaveLength(0);
+    expect(report.exempted).toHaveLength(0);
+    expect(bodies).toHaveLength(0);
+  });
+
+  it("does not flag a Moderate advisory (only Critical/High are findings)", async () => {
+    const { fetcher } = fakeFetcher([
+      {
+        body: {
+          vulns: [
+            vuln({
+              id: "GHSA-mod",
+              database_specific: { severity: "MODERATE" },
+              published: "2026-01-01T00:00:00Z",
+            }),
+          ],
+        },
+      },
+    ]);
+    const report = await checkCliCves({
+      registry: { docker: meta("docker") },
+      maxAgeDays: 30,
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.findings).toHaveLength(0);
+  });
+
+  it("records OSV.dev HTTP errors as queryErrors (warnings, not gate failures)", async () => {
+    const { fetcher } = fakeFetcher([{ status: 503, body: { vulns: [] } }]);
+    const report = await checkCliCves({
+      registry: { docker: meta("docker") },
+      maxAgeDays: 30,
+      fetcher,
+      now: () => NOW,
+    });
+    expect(report.queryErrors).toHaveLength(1);
+    expect(report.queryErrors[0].reason).toMatch(/OSV.dev HTTP 503/);
+    expect(report.findings).toHaveLength(0);
+    expect(report.staleFindings).toHaveLength(0);
+  });
+});
+
+// ── normalizeSeverity / parseCvssBase (mirrors check-mcp-cves) ─────
+
+describe("normalizeSeverity", () => {
+  it("reads database_specific.severity when present", () => {
+    expect(normalizeSeverity(vuln({ database_specific: { severity: "CRITICAL" } }))).toBe(
+      "CRITICAL",
+    );
+    expect(normalizeSeverity(vuln({ database_specific: { severity: "LOW" } }))).toBe("LOW");
+  });
+
+  it("returns UNKNOWN with no severity signal (the docker/podman GO-record blind spot)", () => {
+    // GO-#### records arrive without numeric severity; this is why docker /
+    // podman HIGH advisories are filtered out and tracked in securityNote.
+    expect(normalizeSeverity({ id: "GO-2026-0001", database_specific: {} })).toBe("UNKNOWN");
+  });
+
+  it("falls back to the CVSS bucket when no database_specific severity", () => {
+    expect(
+      normalizeSeverity(vuln({ database_specific: {}, severity: [{ score: "9.8" }] })),
+    ).toBe("CRITICAL");
+  });
+});
+
+describe("parseCvssBase", () => {
+  it("parses a bare numeric string and rejects out-of-range / vectors", () => {
+    expect(parseCvssBase("7.5")).toBe(7.5);
+    expect(parseCvssBase("11.0")).toBeNull();
+    expect(parseCvssBase("CVSS:3.1/AV:N/AC:L/PR:N/UI:N")).toBeNull();
+    expect(parseCvssBase(undefined)).toBeNull();
+  });
+});
+
+// ── formatTextReport ──────────────────────────────────────────────
+
+/** Assemble a CheckReport with sane defaults for formatTextReport tests. */
+function report(overrides: Partial<CheckReport> = {}): CheckReport {
+  return {
+    targets: [],
+    findings: [],
+    staleFindings: [],
+    acknowledgedFindings: [],
+    maxAgeDays: 30,
+    queryErrors: [],
+    unmapped: [],
+    exempted: [],
+    ...overrides,
+  };
+}
+
+describe("formatTextReport", () => {
+  it("(6a) renders the exempted section and a zero unmapped count", () => {
+    const out = formatTextReport(
+      report({
+        targets: [
+          { tool: "docker", category: "container", ecosystem: "Go", name: "github.com/moby/moby" },
+        ],
+        exempted: [{ meta: meta("rtk", { category: "ai" }), reason: "no OSV advisory package" }],
+      }),
+      NOW,
+    );
+    expect(out).toMatch(/unmapped registry entries: 0/);
+    expect(out).toMatch(/exempted \(intentionally not OSV-scanned\): 1/);
+    expect(out).toMatch(/Exempted \(intentionally not OSV-scanned, see SCAN_EXEMPT_TOOLS\):/);
+    expect(out).toMatch(/- rtk \(ai\): no OSV advisory package/);
+  });
+
+  it("(6b) renders an acknowledged advisory with the [ack] tag + reason and excludes it from the gate line", () => {
+    const ackFinding = {
+      target: { tool: "llm", category: "ai", ecosystem: "PyPI", name: "llm", version: undefined },
+      id: "GHSA-g76p-4vg5-f4qh",
+      summary: "code-injection",
+      severity: "CRITICAL" as const,
+      publishedISO: "2026-01-01T00:00:00Z",
+      ageDays: 153,
+      isStale: true,
+      acknowledged: true,
+    };
+    const out = formatTextReport(
+      report({
+        targets: [
+          { tool: "llm", category: "ai", ecosystem: "PyPI", name: "llm", version: undefined },
+        ],
+        findings: [ackFinding],
+        staleFindings: [],
+        acknowledgedFindings: [ackFinding],
+      }),
+      NOW,
+    );
+    expect(out).toMatch(/\[ack\] CRITICAL/);
+    expect(out).toMatch(/acknowledged: llm --functions code-injection is by-design/);
+    expect(out).toMatch(/review by 2026-09-01/);
+    // No FAIL marker, and the gate line reports zero gating advisories.
+    expect(out).not.toMatch(/\[FAIL\]/);
+    expect(out).toMatch(/No gating Critical\/High advisories/);
+  });
+
+  it("prints a 'review overdue' note when reviewBy is in the past (no exit-code change)", () => {
+    const ackFinding = {
+      target: { tool: "llm", category: "ai", ecosystem: "PyPI", name: "llm", version: undefined },
+      id: "GHSA-g76p-4vg5-f4qh",
+      summary: "code-injection",
+      severity: "CRITICAL" as const,
+      publishedISO: "2026-01-01T00:00:00Z",
+      ageDays: 300,
+      isStale: true,
+      acknowledged: true,
+    };
+    // reviewBy is 2026-09-01; pick a `now` after it.
+    const out = formatTextReport(
+      report({ findings: [ackFinding], acknowledgedFindings: [ackFinding] }),
+      new Date("2026-10-01T00:00:00Z"),
+    );
+    expect(out).toMatch(/review overdue \(reviewBy 2026-09-01 has passed\)/);
+  });
+
+  it("surfaces a stale non-acknowledged finding with the FAIL marker", () => {
+    const staleFinding = {
+      target: { tool: "docker", category: "container", ecosystem: "Go", name: "github.com/moby/moby", version: ">=29.5.2" },
+      id: "GHSA-not-acknowledged",
+      summary: "Test summary",
+      severity: "CRITICAL" as const,
+      publishedISO: "2026-01-01T00:00:00Z",
+      ageDays: 153,
+      isStale: true,
+      acknowledged: false,
+    };
+    const out = formatTextReport(
+      report({ findings: [staleFinding], staleFindings: [staleFinding] }),
+      NOW,
+    );
+    expect(out).toMatch(/\[FAIL\] CRITICAL/);
+    expect(out).toMatch(/older than 30 days/);
+  });
+});

--- a/scripts/__tests__/inventory.test.ts
+++ b/scripts/__tests__/inventory.test.ts
@@ -188,9 +188,13 @@ describe("inventory: buildInventory (injectable date)", () => {
 
     const reconciled = reconcileLastUpdated(fresh, committed);
     expect(reconciled.lastUpdated).toBe(committed.lastUpdated);
-    // Full document round-trips byte-for-byte to the committed copy.
-    const rendered = `${JSON.stringify(reconciled, null, 2)}\n`;
-    const committedRaw = await readFile(COMMITTED_INVENTORY, "utf-8");
+    // Full document round-trips byte-for-byte to the committed copy. Normalize
+    // line endings on both sides: `JSON.stringify` always emits `\n`, but a
+    // Windows checkout could read the committed file with `\r\n` (the repo-root
+    // `.gitattributes` forces LF, so this is defense-in-depth — keeps the byte
+    // compare about content, not the platform's line-ending convention).
+    const rendered = `${JSON.stringify(reconciled, null, 2)}\n`.replace(/\r\n/g, "\n");
+    const committedRaw = (await readFile(COMMITTED_INVENTORY, "utf-8")).replace(/\r\n/g, "\n");
     expect(rendered).toBe(committedRaw);
   });
 });

--- a/scripts/__tests__/inventory.test.ts
+++ b/scripts/__tests__/inventory.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildInventory,
+  reconcileLastUpdated,
+  sameInventoryContent,
+  readExistingInventory,
+  type InventoryDocument,
+} from "../inventory.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+const COMMITTED_INVENTORY = join(ROOT, "governance", "inventory.json");
+
+// ── Fixture helpers ────────────────────────────────────────────────
+
+function makeDoc(
+  overrides: Partial<InventoryDocument> = {},
+): InventoryDocument {
+  return {
+    lastUpdated: "2026-01-01",
+    counts: {
+      adapters: 3,
+      agents: 29,
+      skills: 53,
+      cliSkills: 6,
+      rules: 65,
+      rulesMdc: 65,
+      commands: 30,
+      hooks: 7,
+      pipeline: 22,
+      cliCommands: 18,
+      agentsModes: 21,
+      agentsShared: 13,
+      commandsBoard: 11,
+      commandsRevision: 4,
+      checks: 6,
+      githubAgents: 4,
+    },
+    files: {
+      adapters: ["claude.ts", "copilot.ts", "cursor.ts"],
+      agents: ["hatch3r-implementer.md"],
+      skills: ["hatch3r-foo/SKILL.md"],
+      cliSkills: [],
+      rules: ["hatch3r-bar.md"],
+      rulesMdc: ["hatch3r-bar.mdc"],
+      commands: ["hatch3r-baz.md"],
+      hooks: ["hatch3r-hook.md"],
+      pipeline: ["foo.ts"],
+      cliCommands: ["init.ts"],
+      agentsModes: ["mode.md"],
+      agentsShared: ["shared.md"],
+      commandsBoard: ["board.md"],
+      commandsRevision: ["rev.md"],
+      checks: ["security.md"],
+      githubAgents: ["agent.md"],
+    },
+    ...overrides,
+  };
+}
+
+describe("inventory: reconcileLastUpdated (preserve-unless-changed)", () => {
+  it("(a) PRESERVES the committed lastUpdated when content is unchanged, even though 'today' differs", () => {
+    const existing = makeDoc({ lastUpdated: "2026-06-04" });
+    // Fresh build stamped with a LATER day, identical content otherwise.
+    const fresh = makeDoc({ lastUpdated: "2026-09-30" });
+
+    const result = reconcileLastUpdated(fresh, existing);
+
+    expect(result.lastUpdated).toBe("2026-06-04");
+    // The rest of the document is the freshly-built content (here identical).
+    expect(result.counts).toEqual(fresh.counts);
+    expect(result.files).toEqual(fresh.files);
+  });
+
+  it("(b) ADVANCES lastUpdated to 'today' when a count changes", () => {
+    const existing = makeDoc({ lastUpdated: "2026-06-04" });
+    const fresh = makeDoc({
+      lastUpdated: "2026-09-30",
+      counts: { ...existing.counts, rules: 66 },
+    });
+
+    const result = reconcileLastUpdated(fresh, existing);
+
+    expect(result.lastUpdated).toBe("2026-09-30");
+    expect(result.counts.rules).toBe(66);
+  });
+
+  it("(b) ADVANCES lastUpdated to 'today' when a file list changes", () => {
+    const existing = makeDoc({ lastUpdated: "2026-06-04" });
+    const fresh = makeDoc({
+      lastUpdated: "2026-09-30",
+      files: { ...existing.files, rules: ["hatch3r-bar.md", "hatch3r-new.md"] },
+    });
+
+    const result = reconcileLastUpdated(fresh, existing);
+
+    expect(result.lastUpdated).toBe("2026-09-30");
+  });
+
+  it("keeps 'today' when there is no committed file (first generation)", () => {
+    const fresh = makeDoc({ lastUpdated: "2026-09-30" });
+    const result = reconcileLastUpdated(fresh, null);
+    expect(result.lastUpdated).toBe("2026-09-30");
+  });
+});
+
+describe("inventory: sameInventoryContent", () => {
+  it("ignores lastUpdated when comparing", () => {
+    const a = makeDoc({ lastUpdated: "2020-01-01" });
+    const b = makeDoc({ lastUpdated: "2030-12-31" });
+    expect(sameInventoryContent(a, b)).toBe(true);
+  });
+
+  it("detects a counts difference", () => {
+    const a = makeDoc();
+    const b = makeDoc({ counts: { ...makeDoc().counts, hooks: 8 } });
+    expect(sameInventoryContent(a, b)).toBe(false);
+  });
+
+  it("detects a files difference", () => {
+    const a = makeDoc();
+    const b = makeDoc({
+      files: { ...makeDoc().files, hooks: ["hatch3r-hook.md", "extra.md"] },
+    });
+    expect(sameInventoryContent(a, b)).toBe(false);
+  });
+});
+
+describe("inventory: readExistingInventory", () => {
+  it("returns null for a missing file (ENOENT)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "inventory-read-"));
+    try {
+      const result = await readExistingInventory(join(dir, "nope.json"));
+      expect(result).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a malformed JSON file (self-heals to today)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "inventory-read-"));
+    try {
+      const path = join(dir, "inventory.json");
+      await writeFile(path, "{ not valid json", "utf-8");
+      const result = await readExistingInventory(path);
+      expect(result).toBeNull();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("parses a well-formed committed file", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "inventory-read-"));
+    try {
+      const path = join(dir, "inventory.json");
+      const doc = makeDoc({ lastUpdated: "2026-06-04" });
+      await writeFile(path, `${JSON.stringify(doc, null, 2)}\n`, "utf-8");
+      const result = await readExistingInventory(path);
+      expect(result?.lastUpdated).toBe("2026-06-04");
+      expect(result?.counts.rules).toBe(65);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("inventory: buildInventory (injectable date)", () => {
+  it("stamps the injected 'today' verbatim", async () => {
+    const doc = await buildInventory("2099-12-31");
+    expect(doc.lastUpdated).toBe("2099-12-31");
+  });
+
+  it("no-op regen against the real committed inventory is content-identical (gate stays green on any date)", async () => {
+    // Proves the CI drift gate (.github/workflows/ci.yml: npm run inventory &&
+    // git diff --exit-code) only fires on real content drift: a fresh build
+    // stamped with a DIFFERENT day reconciles back to the committed bytes.
+    const committed = JSON.parse(
+      await readFile(COMMITTED_INVENTORY, "utf-8"),
+    ) as InventoryDocument;
+
+    const fresh = await buildInventory("2099-12-31");
+    expect(sameInventoryContent(fresh, committed)).toBe(true);
+
+    const reconciled = reconcileLastUpdated(fresh, committed);
+    expect(reconciled.lastUpdated).toBe(committed.lastUpdated);
+    // Full document round-trips byte-for-byte to the committed copy.
+    const rendered = `${JSON.stringify(reconciled, null, 2)}\n`;
+    const committedRaw = await readFile(COMMITTED_INVENTORY, "utf-8");
+    expect(rendered).toBe(committedRaw);
+  });
+});

--- a/scripts/__tests__/validate-rule-pillar-currency.test.ts
+++ b/scripts/__tests__/validate-rule-pillar-currency.test.ts
@@ -1,7 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Repo root for the real-repo end-to-end run: this file lives at
+// scripts/__tests__/, so the root is two levels up (mirrors
+// validate-specialist-roster.test.ts REPO_ROOT resolution).
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const CONSTITUTION_REL = "governance/CONSTITUTION.md";
 
 import {
   checkContentAuthoringFile,
@@ -363,11 +373,21 @@ describe("runValidator", () => {
 describe("runValidator (real repo)", () => {
   it("passes against the current repo state (post-H76 propagation)", async () => {
     const result = await runValidator(); // default rootDir = repo root
-    // After C9-H76 propagated P8, repo must be in sync.
-    expect(result.pillarCount).toBeGreaterThanOrEqual(8);
-    // The full canonical surface is verified by the script; any drift here
-    // would mean a rule file lost its P8 reference between H76 and gate run.
-    expect(result.errorCount).toBe(0);
+    // Privatization gate: governance/CONSTITUTION.md is private and absent in
+    // public CI / contributor clones. With no canonical pillar count to
+    // cross-check, runValidator returns the graceful-skip contract
+    // (validate-rule-pillar-currency.ts:292-298). Assert that contract when the
+    // source is absent; assert the post-H76 in-sync contract when it is present.
+    if (existsSync(resolve(REPO_ROOT, CONSTITUTION_REL))) {
+      // After C9-H76 propagated P8, repo must be in sync.
+      expect(result.pillarCount).toBeGreaterThanOrEqual(8);
+      // The full canonical surface is verified by the script; any drift here
+      // would mean a rule file lost its P8 reference between H76 and gate run.
+      expect(result.errorCount).toBe(0);
+    } else {
+      expect(result.pillarCount).toBe(0);
+      expect(result.errorCount).toBe(0);
+    }
   });
 });
 

--- a/scripts/__tests__/validate-rule-pillar-currency.test.ts
+++ b/scripts/__tests__/validate-rule-pillar-currency.test.ts
@@ -11,7 +11,12 @@ import { fileURLToPath } from "node:url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const REPO_ROOT = resolve(__dirname, "..", "..");
-const CONSTITUTION_REL = "governance/CONSTITUTION.md";
+// Build with path.join so the existsSync probe targets the same native path the
+// validator's `join(rootDir, ...)` resolves to on every OS (avoid an embedded
+// "/" literal that the cookbook flags). On Windows CI governance/ is absent
+// (gitignored, private), so the real-repo test asserts the graceful-skip
+// contract; this keeps the present/absent branch selection unambiguous there.
+const CONSTITUTION_REL = join("governance", "CONSTITUTION.md");
 
 import {
   checkContentAuthoringFile,

--- a/scripts/check-cli-cves.ts
+++ b/scripts/check-cli-cves.ts
@@ -85,16 +85,32 @@ export interface VulnerabilityFinding {
   publishedISO?: string;
   ageDays?: number;
   isStale: boolean;
+  /**
+   * True when the advisory id is in ACKNOWLEDGED_ADVISORIES — a Critical/High
+   * advisory with no upstream fix that is reported but excluded from the gate.
+   */
+  acknowledged: boolean;
+}
+
+/** A tool exempted from OSV scanning, paired with its documented reason. */
+export interface ExemptedTool {
+  meta: CliToolMeta;
+  reason: string;
 }
 
 export interface CheckReport {
   targets: CliToolTarget[];
   findings: VulnerabilityFinding[];
+  /** Stale Critical/High findings that trip the gate (acknowledged excluded). */
   staleFindings: VulnerabilityFinding[];
+  /** Findings whose advisory id is acknowledged (reported, never gating). */
+  acknowledgedFindings: VulnerabilityFinding[];
   maxAgeDays: number;
   queryErrors: Array<{ target: CliToolTarget; reason: string }>;
   /** Tools the registry could not map to an OSV.dev ecosystem. */
   unmapped: CliToolMeta[];
+  /** Tools intentionally not OSV-scanned (documented in SCAN_EXEMPT_TOOLS). */
+  exempted: ExemptedTool[];
 }
 
 export interface RunOptions {
@@ -171,11 +187,29 @@ const ECOSYSTEM_OVERRIDES: Record<string, { ecosystem: string; name: string }> =
   dasel: { ecosystem: "Go", name: "github.com/tomwright/dasel" },
   duckdb: { ecosystem: "Go", name: "github.com/duckdb/duckdb" },
   lazygit: { ecosystem: "Go", name: "github.com/jesseduffield/lazygit" },
+  // docker + podman: their real HIGH advisories — docker CVE-2026-34040
+  // (GHSA-x744-4wpc-v9h2); podman CVE-2024-3056 (GHSA-rpcc-p8xm-rc6p) and
+  // CVE-2025-4953 (GHSA-m68q-4hqr-mc6f) — are returned by OSV as Go-ecosystem
+  // (GO-####) records WITHOUT a numeric severity, so `normalizeSeverity`
+  // classifies them UNKNOWN and they are filtered out below. This is a known
+  // blind spot: these advisories have no upstream fix and are tracked instead
+  // in each tool's registry `securityNote`. Fixing `normalizeSeverity` to read
+  // GO-record severity is a separate follow-up, not handled here.
+  docker: { ecosystem: "Go", name: "github.com/moby/moby" },
+  podman: { ecosystem: "Go", name: "github.com/containers/podman/v5" },
+  mods: { ecosystem: "Go", name: "github.com/charmbracelet/mods" },
+  miller: { ecosystem: "Go", name: "github.com/johnkerl/miller/v6" },
+  "container-use": { ecosystem: "Go", name: "github.com/dagger/container-use" },
 
   // Python (PyPI) tools.
   csvkit: { ecosystem: "PyPI", name: "csvkit" },
   llm: { ecosystem: "PyPI", name: "llm" },
   httpie: { ecosystem: "PyPI", name: "httpie" },
+  // az-devops maps to the `azure-devops` PyPI extension package, NOT
+  // `azure-cli`: azure-cli carries a stale HIGH advisory and the registry pins
+  // the extension version (1.0.4), which does not exist on the azure-cli
+  // package, so querying azure-cli would version-mismatch and mis-report.
+  "az-devops": { ecosystem: "PyPI", name: "azure-devops" },
 
   // npm-distributed tools.
   playwright: { ecosystem: "npm", name: "@playwright/test" },
@@ -185,6 +219,34 @@ const ECOSYSTEM_OVERRIDES: Record<string, { ecosystem: string; name: string }> =
   jq: { ecosystem: "Linux", name: "jq" },
   curl: { ecosystem: "Linux", name: "curl" },
   zstd: { ecosystem: "Linux", name: "zstd" },
+};
+
+/**
+ * Tools intentionally NOT OSV-scanned (no clean ecosystem target). Keyed by
+ * registry id -> reason. They are reported separately (the `exempted` bucket),
+ * never as "unmapped" — an exemption is a documented decision, an unmapped
+ * entry is an unfilled gap.
+ */
+const SCAN_EXEMPT_TOOLS: Record<string, string> = {
+  rtk: "crates.io 'rtk' is an unrelated project; rtk-ai/rtk ships only via git/Homebrew/scoop install scripts — no OSV advisory package",
+  comby: "comby-tools/comby ships only as a GitHub-release binary / opam — no npm/Go/PyPI/crates OSV advisory package",
+};
+
+/**
+ * Critical/High advisories explicitly acknowledged (no upstream fix available).
+ * Acknowledged ids are still REPORTED (with reason) but do NOT fail the gate.
+ * Review each by its reviewBy date.
+ */
+const ACKNOWLEDGED_ADVISORIES: Record<
+  string,
+  { reason: string; addedISO: string; reviewBy: string }
+> = {
+  "GHSA-g76p-4vg5-f4qh": {
+    reason:
+      "llm --functions code-injection is by-design (arbitrary Python via a user-invoked flag); OSV lists no upstream fix. Mitigation: never pass untrusted input to `llm --functions`.",
+    addedISO: "2026-06-03",
+    reviewBy: "2026-09-01",
+  },
 };
 
 /**
@@ -295,7 +357,15 @@ export async function checkCliCves(opts: RunOptions = {}): Promise<CheckReport> 
 
   const targets: CliToolTarget[] = [];
   const unmapped: CliToolMeta[] = [];
+  const exempted: ExemptedTool[] = [];
   for (const meta of Object.values(registry)) {
+    const exemptReason = SCAN_EXEMPT_TOOLS[meta.id];
+    if (exemptReason !== undefined) {
+      // Documented no-scan decision: report separately, never query, never
+      // count as unmapped.
+      exempted.push({ meta, reason: exemptReason });
+      continue;
+    }
     const target = mapToolToOsvTarget(meta);
     if (target) targets.push(target);
     else unmapped.push(meta);
@@ -327,33 +397,63 @@ export async function checkCliCves(opts: RunOptions = {}): Promise<CheckReport> 
         publishedISO,
         ageDays,
         isStale,
+        acknowledged: ACKNOWLEDGED_ADVISORIES[v.id] !== undefined,
       });
     }
   }
 
-  const staleFindings = findings.filter((f) => f.isStale);
-  return { targets, findings, staleFindings, maxAgeDays, queryErrors, unmapped };
+  // Acknowledged advisories are reported but never gate: a stale acknowledged
+  // finding is excluded from staleFindings so the documented no-fix advisory
+  // does not fail the build.
+  const staleFindings = findings.filter((f) => f.isStale && !f.acknowledged);
+  const acknowledgedFindings = findings.filter((f) => f.acknowledged);
+  return {
+    targets,
+    findings,
+    staleFindings,
+    acknowledgedFindings,
+    maxAgeDays,
+    queryErrors,
+    unmapped,
+    exempted,
+  };
 }
 
 // ── Output formatting ─────────────────────────────────────────────
 
-export function formatTextReport(report: CheckReport): string {
+export function formatTextReport(report: CheckReport, now: Date = new Date()): string {
   const lines: string[] = [];
   lines.push("check-cli-cves:");
   lines.push(`  targets queried: ${report.targets.length}`);
   lines.push(`  Critical/High findings: ${report.findings.length}`);
   lines.push(`  stale (>${report.maxAgeDays} days): ${report.staleFindings.length}`);
+  lines.push(`  acknowledged (reported, not gating): ${report.acknowledgedFindings.length}`);
   lines.push(`  unmapped registry entries: ${report.unmapped.length}`);
+  lines.push(`  exempted (intentionally not OSV-scanned): ${report.exempted.length}`);
   if (report.findings.length > 0) {
     lines.push("");
     lines.push("  Critical/High advisories:");
     for (const f of report.findings) {
       const age = f.ageDays !== undefined ? `${f.ageDays}d` : "age unknown";
-      const tag = f.isStale ? "FAIL" : "warn";
+      // Acknowledged advisories render [ack] (no FAIL/warn) — they are reported
+      // for visibility but excluded from the gate by construction.
+      const tag = f.acknowledged ? "ack" : f.isStale ? "FAIL" : "warn";
       lines.push(
         `    [${tag}] ${f.severity.padEnd(8)} ${f.id}  ${f.target.tool} (${f.target.ecosystem}/${f.target.name}@${f.target.version ?? "unpinned"}) (${age})`,
       );
       if (f.summary) lines.push(`           ${f.summary}`);
+      if (f.acknowledged) {
+        const ack = ACKNOWLEDGED_ADVISORIES[f.id];
+        if (ack) {
+          lines.push(`           acknowledged: ${ack.reason}`);
+          lines.push(`           added ${ack.addedISO}, review by ${ack.reviewBy}`);
+          if (Date.parse(ack.reviewBy) < now.getTime()) {
+            lines.push(
+              `           review overdue (reviewBy ${ack.reviewBy} has passed) — re-verify the no-fix status`,
+            );
+          }
+        }
+      }
     }
   }
   if (report.queryErrors.length > 0) {
@@ -370,14 +470,26 @@ export function formatTextReport(report: CheckReport): string {
       lines.push(`    - ${meta.id} (${meta.category})`);
     }
   }
+  if (report.exempted.length > 0) {
+    lines.push("");
+    lines.push("  Exempted (intentionally not OSV-scanned, see SCAN_EXEMPT_TOOLS):");
+    for (const ex of report.exempted) {
+      lines.push(`    - ${ex.meta.id} (${ex.meta.category}): ${ex.reason}`);
+    }
+  }
   lines.push("");
+  const gatingFindings = report.findings.length - report.acknowledgedFindings.length;
   if (report.staleFindings.length > 0) {
     lines.push(
-      `  ${report.staleFindings.length} Critical/High advisory(ies) older than ${report.maxAgeDays} days. Bump pinned minVersion in src/cliTools/registry.ts or open an exception note.`,
+      `  ${report.staleFindings.length} Critical/High advisory(ies) older than ${report.maxAgeDays} days (acknowledged advisories excluded). Bump pinned minVersion in src/cliTools/registry.ts or open an exception note.`,
     );
-  } else if (report.findings.length > 0) {
+  } else if (gatingFindings > 0) {
     lines.push(
-      `  All ${report.findings.length} Critical/High advisory(ies) within the ${report.maxAgeDays}-day window. No gate failure; bump on the next cycle.`,
+      `  All ${gatingFindings} gating Critical/High advisory(ies) within the ${report.maxAgeDays}-day window. No gate failure; bump on the next cycle.`,
+    );
+  } else if (report.acknowledgedFindings.length > 0) {
+    lines.push(
+      `  No gating Critical/High advisories across ${report.targets.length} CLI tool(s) queried (${report.acknowledgedFindings.length} acknowledged advisory(ies) reported above, excluded from the gate).`,
     );
   } else {
     lines.push(
@@ -391,13 +503,14 @@ export function formatTextReport(report: CheckReport): string {
 
 async function main(): Promise<void> {
   const flags = parseArgs(process.argv.slice(2));
-  const report = await checkCliCves({ maxAgeDays: flags.maxAgeDays });
+  const now = new Date();
+  const report = await checkCliCves({ maxAgeDays: flags.maxAgeDays, now: () => now });
   if (flags.json) {
     // eslint-disable-next-line no-console
     console.log(JSON.stringify(report, null, 2));
   } else {
     // eslint-disable-next-line no-console
-    console.log(formatTextReport(report));
+    console.log(formatTextReport(report, now));
   }
   if (report.staleFindings.length > 0) process.exit(1);
 }

--- a/scripts/inventory.ts
+++ b/scripts/inventory.ts
@@ -91,7 +91,7 @@ interface InventoryFiles {
   githubAgents: string[];
 }
 
-interface InventoryDocument {
+export interface InventoryDocument {
   lastUpdated: string;
   counts: InventoryCounts;
   files: InventoryFiles;
@@ -203,7 +203,16 @@ async function listSrcDirTs(relDir: string): Promise<string[]> {
   );
 }
 
-async function buildInventory(): Promise<InventoryDocument> {
+/**
+ * Build the inventory document from the filesystem.
+ *
+ * `today` is injected (date-only `YYYY-MM-DD`, UTC) rather than read inline so
+ * the function is deterministic and testable (`.claude/rules/test-requirements.md`).
+ * `main()` passes `new Date().toISOString().slice(0, 10)`; the returned
+ * `lastUpdated` is provisional — `reconcileLastUpdated` may rewind it to the
+ * committed value when the substantive content is unchanged.
+ */
+export async function buildInventory(today: string): Promise<InventoryDocument> {
   const [
     adapters,
     agents,
@@ -237,10 +246,6 @@ async function buildInventory(): Promise<InventoryDocument> {
     listCompanionMd("checks"),
     listCompanionMd("github-agents"),
   ]);
-
-  // Use a date-only stamp (UTC) so the file is stable across same-day runs
-  // and the CI drift check does not flap on every CI execution.
-  const today = new Date().toISOString().slice(0, 10);
 
   const cliSkills = listCliSkills(skills);
 
@@ -283,6 +288,78 @@ async function buildInventory(): Promise<InventoryDocument> {
       githubAgents,
     },
   };
+}
+
+/**
+ * Read and parse the committed `governance/inventory.json`, if present.
+ *
+ * Returns `null` on ENOENT (no committed file yet) or on malformed JSON — in
+ * both cases the caller falls back to stamping today's date. Any other read
+ * error (permissions, I/O) is rethrown so a genuine fault is not masked.
+ */
+export async function readExistingInventory(
+  outPath: string,
+): Promise<InventoryDocument | null> {
+  let raw: string;
+  try {
+    raw = await readFile(outPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  try {
+    return JSON.parse(raw) as InventoryDocument;
+  } catch (err) {
+    // Malformed committed file — surface a diagnostic (CONSTITUTION.md §2 P5
+    // Silent Failure Contract) then treat as absent so the regen self-heals by
+    // stamping today's date and rewriting valid JSON.
+    console.warn(
+      `inventory: committed ${outPath} is not valid JSON ` +
+        `(${(err as Error).message}); regenerating with today's date.`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Structural equality of two inventory documents IGNORING `lastUpdated`.
+ *
+ * Compares `counts` + `files` (every counter and file list). `buildInventory`
+ * emits keys in a fixed insertion order and the committed file is produced the
+ * same way, so a stable `JSON.stringify` of `{ counts, files }` is an exact
+ * content comparison. A committed file with reordered or extra keys (e.g. a
+ * hand-edit) deserializes back through `JSON.parse`, so a non-matching shape
+ * compares unequal and correctly triggers a today-stamp + rewrite.
+ */
+export function sameInventoryContent(
+  a: InventoryDocument,
+  b: InventoryDocument,
+): boolean {
+  const strip = (doc: InventoryDocument): string =>
+    JSON.stringify({ counts: doc.counts, files: doc.files });
+  return strip(a) === strip(b);
+}
+
+/**
+ * Preserve-unless-changed reconciliation of `lastUpdated`.
+ *
+ * `fresh` carries today's date (from `buildInventory(today)`). When a committed
+ * `existing` document is present AND its substantive content (counts + files)
+ * matches `fresh`, the committed `lastUpdated` is reused so a no-op regen is a
+ * byte-for-byte no-op (the CI drift gate at `.github/workflows/ci.yml` passes
+ * every day, not just on the day content last changed). When content differs —
+ * or there is no committed file — `fresh` (today) is kept, so `lastUpdated`
+ * advances only on real content drift. Pillars: P5 (the gate stops flapping),
+ * P4 (the field stops lying "updated today" when nothing changed).
+ */
+export function reconcileLastUpdated(
+  fresh: InventoryDocument,
+  existing: InventoryDocument | null,
+): InventoryDocument {
+  if (existing && sameInventoryContent(fresh, existing)) {
+    return { ...fresh, lastUpdated: existing.lastUpdated };
+  }
+  return fresh;
 }
 
 /**
@@ -485,8 +562,14 @@ async function checkDocDrift(
 
 async function main(): Promise<void> {
   const checkDocs = process.argv.includes("--check-docs");
-  const inventory = await buildInventory();
+  const today = new Date().toISOString().slice(0, 10);
   const outPath = join(ROOT, "governance", "inventory.json");
+  const fresh = await buildInventory(today);
+  // Preserve the committed lastUpdated when the substantive content is
+  // unchanged, so a no-op regen is byte-identical and the CI drift gate does
+  // not flap on the date alone.
+  const existing = await readExistingInventory(outPath);
+  const inventory = reconcileLastUpdated(fresh, existing);
   const json = `${JSON.stringify(inventory, null, 2)}\n`;
   await writeFile(outPath, json, "utf-8");
   // eslint-disable-next-line no-console
@@ -539,8 +622,14 @@ async function main(): Promise<void> {
   process.exit(1);
 }
 
-main().catch((err) => {
-  // eslint-disable-next-line no-console
-  console.error("inventory failed:", err);
-  process.exit(1);
-});
+// Only auto-run when executed as a script (not when imported by a test).
+// resolve() on a string never throws, so no defensive catch is needed.
+const isMain = resolve(process.argv[1] ?? "") === __filename;
+
+if (isMain) {
+  main().catch((err) => {
+    // eslint-disable-next-line no-console
+    console.error("inventory failed:", err);
+    process.exit(1);
+  });
+}

--- a/src/__tests__/cli/commands/init.userPrompt.test.ts
+++ b/src/__tests__/cli/commands/init.userPrompt.test.ts
@@ -25,6 +25,19 @@ vi.mock("inquirer", () => {
   };
 });
 
+// CI determinism: interactive init calls findMissingCliTools (real PATH probe)
+// then offerInstaller (an extra inquirer.prompt) for any tool absent from PATH.
+// On a clean CI runner the selected tools are missing, so that extra prompt
+// fires and shifts every test's queued inquirer answer by one. Mock detection
+// to "nothing missing" so the prompt sequence is machine-independent. Mirrors
+// src/__tests__/cli/config.test.ts:177.
+vi.mock("../../../cliTools/detect.js", () => ({
+  findMissingCliTools: vi.fn().mockResolvedValue([]),
+  detectCliTool: vi.fn(),
+  detectCliTools: vi.fn().mockResolvedValue([]),
+  probeBin: vi.fn().mockResolvedValue(""),
+}));
+
 describe("init post-init tip", () => {
   let initCommand: (opts?: { tools?: string; yes?: boolean }) => Promise<void>;
   let tempDir: string;

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -22,6 +22,21 @@ vi.mock("inquirer", () => {
   };
 });
 
+// CI determinism: interactive init calls findMissingCliTools (real PATH probe)
+// then offerInstaller (an extra inquirer.prompt) for any tool absent from PATH.
+// On a clean CI runner the selected tools are missing, so that extra prompt
+// fires and shifts every test's queued inquirer answer by one — surfacing as
+// "Cannot destructure property 'proceed'/'syncRepos'". Mock detection to
+// "nothing missing" so the prompt sequence is machine-independent. Mirrors
+// src/__tests__/cli/config.test.ts:177. Tests that exercise the installer
+// path can override with mockResolvedValueOnce.
+vi.mock("../../cliTools/detect.js", () => ({
+  findMissingCliTools: vi.fn().mockResolvedValue([]),
+  detectCliTool: vi.fn(),
+  detectCliTools: vi.fn().mockResolvedValue([]),
+  probeBin: vi.fn().mockResolvedValue(""),
+}));
+
 // Wave 6 (1.9.0): the hatch3r footprint moved from `.agents/` to `.hatch3r/`.
 // For the rewritten init tests, `AGENTS_DIR` refers to `.hatch3r/` so existing
 // `join(tempDir, AGENTS_DIR, "hatch.json")` reads pick up the new location.

--- a/src/__tests__/cli/sync.test.ts
+++ b/src/__tests__/cli/sync.test.ts
@@ -88,7 +88,12 @@ describe("sync command", () => {
     exitSpy.mockRestore();
     consoleSpy.mockRestore();
     consoleErrorSpy.mockRestore();
-    await rm(tempDir, { recursive: true, force: true });
+    // Windows defers deletion of files with open handles and locks them while
+    // open, so an immediate recursive rmdir can throw ENOTEMPTY/EBUSY/EPERM on
+    // a freshly-written temp tree. fs.rm retries exactly those errnos with a
+    // linear backoff when recursive:true (Node fs docs, accessed 2026-06-04:
+    // https://nodejs.org/api/fs.html). Inert on POSIX (first attempt succeeds).
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("should exit with error when no manifest exists", async () => {

--- a/src/__tests__/cliTools/skill.test.ts
+++ b/src/__tests__/cliTools/skill.test.ts
@@ -13,23 +13,27 @@ import { AVAILABLE_CLI_TOOLS, type CliToolMeta } from "../../cliTools/registry.j
  * script remains idempotent.
  */
 
-describe("renderCliToolSkillBody — ripgrep (tier-1 representative)", () => {
+describe("renderCliToolSkillBody — fd (tier-1 representative)", () => {
   it("matches a stable inline snapshot for the mac OS path", () => {
-    const ripgrep = AVAILABLE_CLI_TOOLS.ripgrep as CliToolMeta;
-    const body = renderCliToolSkillBody(ripgrep, "mac");
+    // fd is the minVersion-less / securityNote-less tier-1 representative for
+    // the no-Security-section scaffold snapshot. (ripgrep was the prior
+    // fixture but now carries a CVE-2021-3013 minVersion floor, which would
+    // append a ## Security block.)
+    const fd = AVAILABLE_CLI_TOOLS.fd as CliToolMeta;
+    const body = renderCliToolSkillBody(fd, "mac");
 
     // Snapshot of the generator scaffold — Wave 4 swaps the three placeholder
     // sections with per-tool authored content; the wrapper structure (When
     // to Use, Token Cost, Recipes, Wrong Choice When, Alternatives,
     // Detection / Install, Homepage) is part of the contract.
     expect(body).toMatchInlineSnapshot(`
-      "# ripgrep
+      "# fd
 
-      Fast recursive grep with sane defaults and gitignore awareness
+      User-friendly find replacement, gitignore-aware
 
       ## When to Use
 
-      Reach for \`rg\` when the task is in the **search** category and the agent would otherwise call an MCP tool or read large outputs into context.
+      Reach for \`fd\` when the task is in the **search** category and the agent would otherwise call an MCP tool or read large outputs into context.
 
       ## Token Cost
 
@@ -52,31 +56,31 @@ describe("renderCliToolSkillBody — ripgrep (tier-1 representative)", () => {
 
       Verify with:
       \`\`\`bash
-      command -v rg
+      command -v fd
       \`\`\`
 
       Install (macOS — default for this machine):
 
       \`\`\`bash
       # brew
-      brew install ripgrep
+      brew install fd
       \`\`\`
 
       Install (Linux):
 
       \`\`\`bash
       # apt
-      sudo apt install ripgrep
+      sudo apt install fd-find
       \`\`\`
 
       Install (Windows):
 
       \`\`\`bash
       # scoop
-      scoop install ripgrep
+      scoop install fd
       \`\`\`
 
-      Homepage: https://github.com/BurntSushi/ripgrep
+      Homepage: https://github.com/sharkdp/fd
       "
     `);
   });
@@ -139,10 +143,11 @@ describe("renderCliToolSkillBody — Security section (F15.7-H7, Cycle 10 D15-SA
   });
 
   it("omits the ## Security section for tools with no securityNote or minVersion", () => {
-    // ripgrep has neither field — its body must stay free of the Security
-    // heading so the no-advisory path is unchanged.
-    const ripgrep = AVAILABLE_CLI_TOOLS.ripgrep as CliToolMeta;
-    const body = renderCliToolSkillBody(ripgrep, "mac");
+    // fd has neither field — its body must stay free of the Security
+    // heading so the no-advisory path is unchanged. (ripgrep now carries a
+    // CVE-2021-3013 minVersion floor, so fd is the minVersion-less fixture.)
+    const fd = AVAILABLE_CLI_TOOLS.fd as CliToolMeta;
+    const body = renderCliToolSkillBody(fd, "mac");
     expect(body).not.toContain("## Security");
   });
 });

--- a/src/__tests__/cliTools/skill.test.ts
+++ b/src/__tests__/cliTools/skill.test.ts
@@ -5,7 +5,7 @@ import { AVAILABLE_CLI_TOOLS, type CliToolMeta } from "../../cliTools/registry.j
 /**
  * Wave 5 Item 28: `src/cliTools/skill.ts::renderCliToolSkillBody` tests.
  *
- * Snapshots the body output for one tier-1 representative (ripgrep) and
+ * Snapshots the body output for one tier-1 representative (fd) and
  * verifies RTK's caveat heading + `rtk proxy` mitigation appear in the
  * rendered output. Also checks the scaffold's placeholder
  * contract for non-caveat tools — Wave 4 cleanup replaces these inline,

--- a/src/__tests__/content/index.copy.test.ts
+++ b/src/__tests__/content/index.copy.test.ts
@@ -7,7 +7,6 @@ import type { ContentSelection } from "../../types.js";
 import {
   buildContentIndex,
   copySelectedContent,
-  generateMdcCompanions,
 } from "../../content/index.js";
 import type { CatalogItem, ContentIndex } from "../../content/index.js";
 import {

--- a/src/__tests__/content/index.crossref.test.ts
+++ b/src/__tests__/content/index.crossref.test.ts
@@ -6,7 +6,6 @@ import type { ContentSelection } from "../../types.js";
 import {
   buildContentIndex,
   extractContentReferences,
-  extractBareContentReferences,
   validateCrossReferences,
   validateOrchestrationDependencies,
 } from "../../content/index.js";

--- a/src/__tests__/content/index.queries.test.ts
+++ b/src/__tests__/content/index.queries.test.ts
@@ -16,7 +16,6 @@ import {
   countPresetExclusions,
   countProjectTypeExclusions,
   countTeamSizeExclusions,
-  estimatePresetItemCount,
   applyCommandPrefix,
   COMMAND_ID_PREFIX,
 } from "../../content/index.js";

--- a/src/__tests__/content/userContent.test.ts
+++ b/src/__tests__/content/userContent.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, mkdir, writeFile, readFile, stat, rm, access } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
@@ -1466,6 +1467,16 @@ describe("lean-threshold doc round-trip (F20.1.E1)", () => {
   // runtime map so drift between the audit doc and the gate is a CI failure
   // (recommendation step 2).
   it("D20-user-content-authoring.md lean row matches the runtime LEAN_LINE_THRESHOLDS", async () => {
+    // Public-only invariant (runs with or without governance): the runtime map
+    // must carry the five published content-type keys the D20 lean row inlines.
+    // This keeps the test meaningful where the private doc is absent.
+    for (const type of ["agent", "command", "skill", "rule", "hook"]) {
+      expect(
+        Object.keys(LEAN_LINE_THRESHOLDS),
+        `LEAN_LINE_THRESHOLDS must define the ${type} threshold`,
+      ).toContain(type);
+    }
+
     // src/__tests__/content/userContent.test.ts → repo root is three levels up.
     const repoRoot = resolve(__dirname, "..", "..", "..");
     const docPath = join(
@@ -1475,6 +1486,15 @@ describe("lean-threshold doc round-trip (F20.1.E1)", () => {
       "domains",
       "D20-user-content-authoring.md",
     );
+
+    // Privatization gate: the D20 audit domain is private and absent in public
+    // CI / contributor clones (only governance/inventory.json ships). When the
+    // doc is absent there is no round-trip to perform — skip the doc-vs-runtime
+    // cross-check cleanly, mirroring the validators' existsSync absence guard
+    // (e.g. validate-lean-threshold-currency.ts:363-369). The public-only
+    // assertion above still guards the runtime map.
+    if (!existsSync(docPath)) return;
+
     const doc = await readFile(docPath, "utf-8");
 
     // Extract every "<type> <number>" pair the lean row inlines.

--- a/src/__tests__/install/selfUpdate.test.ts
+++ b/src/__tests__/install/selfUpdate.test.ts
@@ -15,23 +15,38 @@ vi.mock("node:child_process", async (importOriginal) => {
 describe("runSelfUpdate", () => {
   let tempDir: string;
   const originalArgv1 = process.argv[1];
-  const originalPlatform = process.platform;
+  // Capture the full descriptor (not just the string) so the restore is a
+  // faithful round-trip and every stub carries `configurable: true` — without
+  // it a real Windows runner (`process.platform === "win32"` at capture) would
+  // pin the property non-configurable on the first define and throw
+  // `TypeError: Cannot redefine property` on the next beforeEach/win32 stub.
+  const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+    process,
+    "platform",
+  );
+  const setPlatform = (value: NodeJS.Platform): void => {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  };
 
   beforeEach(async () => {
     tempDir = await mkdtemp(join(tmpdir(), "hatch3r-self-update-"));
     _resetNpmGlobalRootCacheForTesting();
     vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
-    // Pin platform to linux so the Windows-shim guard at
-    // src/install/selfUpdate.ts:143 does not fire for tests that exercise
-    // the global-install branch. The dedicated win32 test below explicitly
-    // overrides this. afterEach restores the originalPlatform captured
-    // outside the describe.
-    Object.defineProperty(process, "platform", { value: "linux" });
+    // Stub platform to a non-Windows value so the Windows-shim guard in
+    // src/install/selfUpdate.ts (the `target.kind === "global" &&
+    // process.platform === "win32"` skip) does NOT fire for tests that
+    // exercise the global-install branch. Tests asserting non-Windows
+    // behaviour MUST pin a non-win32 value here rather than relying on the
+    // host, or they flip on a real Windows runner. The dedicated win32 test
+    // below explicitly overrides this to "win32".
+    setPlatform("linux");
   });
 
   afterEach(async () => {
     process.argv[1] = originalArgv1;
-    Object.defineProperty(process, "platform", { value: originalPlatform });
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
     await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 200 });
   });
 
@@ -114,7 +129,10 @@ describe("runSelfUpdate", () => {
   });
 
   it("skips global self-update on Windows with guided message", async () => {
-    Object.defineProperty(process, "platform", { value: "win32" });
+    // Assert Windows-specific behaviour by STUBBING win32 deterministically
+    // (configurable so afterEach can restore) — never rely on the host
+    // platform, which would make this pass only on a real Windows runner.
+    setPlatform("win32");
     await seedGlobalInstall();
     const fakeRoot = join(tempDir, "fake-global-root");
     process.argv[1] = join(fakeRoot, "hatch3r", "dist", "cli", "index.js");

--- a/src/__tests__/merge/managedBlocks.test.ts
+++ b/src/__tests__/merge/managedBlocks.test.ts
@@ -5,6 +5,8 @@ import {
   extractCustomContent,
   hasManagedBlock,
   wrapInManagedBlock,
+  wrapManagedFor,
+  wouldChangeMarkerVariant,
 } from "../../merge/managedBlocks.js";
 import { HatchError } from "../../types.js";
 
@@ -156,6 +158,67 @@ describe("managedBlocks", () => {
     // that the next hatch3r sync rewrites — the worktree-setup symptom.
     it("emits a POSIX final newline", () => {
       expect(wrapInManagedBlock("body").endsWith("\n")).toBe(true);
+    });
+  });
+
+  // D11-SA11.2-F8 (Cycle 10 Wave 4): wrapManagedFor is the mandatory-path
+  // marker-emission entry point adapter authors MUST use. Because `path` is a
+  // required positional arg, an author cannot fall back to the markdown
+  // default on a .yml output (which would re-introduce issue #76). Assert the
+  // path drives the variant just like wrapInManagedBlock(content, path).
+  describe("wrapManagedFor", () => {
+    it("emits HTML markers for a markdown path", () => {
+      const wrapped = wrapManagedFor("AGENTS.md", "body");
+      expect(wrapped).toBe(`${START}\nbody\n${END}\n`);
+    });
+
+    it("emits YAML markers for a .yml path (issue #76 guard)", () => {
+      const wrapped = wrapManagedFor(".github/workflows/copilot-setup-steps.yml", "name: ci");
+      expect(wrapped).toBe("# HATCH3R:BEGIN\nname: ci\n# HATCH3R:END\n");
+      expect(wrapped).not.toContain("<!--");
+    });
+
+    it("emits YAML markers for a .yaml path", () => {
+      expect(wrapManagedFor("config.yaml", "k: v").startsWith("# HATCH3R:BEGIN")).toBe(true);
+    });
+
+    it("trims the body and appends a POSIX final newline", () => {
+      const wrapped = wrapManagedFor("AGENTS.md", "  padded  ");
+      expect(wrapped).toBe(`${START}\npadded\n${END}\n`);
+    });
+
+    it("produces output round-trip-detectable by hasManagedBlock", () => {
+      expect(hasManagedBlock(wrapManagedFor("x.yml", "k: v"))).toBe(true);
+    });
+  });
+
+  // D11-SA11.2-F11 (Cycle 10 Wave 4): wouldChangeMarkerVariant reports whether
+  // an insertManagedBlock write would flip the on-disk marker variant (the
+  // issue #76 HTML→YAML auto-repair) so safeWriteFile can surface a warning.
+  describe("wouldChangeMarkerVariant", () => {
+    it("returns false when the content has NO detectable managed block", () => {
+      // The no-block branch (early return false) — handled separately by callers.
+      expect(wouldChangeMarkerVariant("no markers at all", "x.yml")).toBe(false);
+      expect(wouldChangeMarkerVariant(`${START}\nonly start, no end`, "x.yml")).toBe(false);
+    });
+
+    it("returns true when HTML markers live in a .yml file (variant would flip to YAML)", () => {
+      const htmlInYaml = `${START}\nold: value\n${END}\n`;
+      expect(wouldChangeMarkerVariant(htmlInYaml, "x.yml")).toBe(true);
+    });
+
+    it("returns false when the detected variant already matches the file type", () => {
+      // HTML markers in a markdown file — no flip.
+      expect(wouldChangeMarkerVariant(`${START}\nbody\n${END}`, "AGENTS.md")).toBe(false);
+      // YAML markers in a .yml file — no flip.
+      expect(
+        wouldChangeMarkerVariant("# HATCH3R:BEGIN\nk: v\n# HATCH3R:END\n", "x.yml"),
+      ).toBe(false);
+    });
+
+    it("returns true when YAML markers live in a markdown file (would flip to HTML)", () => {
+      const yamlInMd = "# HATCH3R:BEGIN\nbody\n# HATCH3R:END\n";
+      expect(wouldChangeMarkerVariant(yamlInMd, "AGENTS.md")).toBe(true);
     });
   });
 

--- a/src/__tests__/merge/orphanCleanup.errorBranches.test.ts
+++ b/src/__tests__/merge/orphanCleanup.errorBranches.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { formatOrphanCleanupDiagnostic } from "../../merge/orphanCleanup.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Error/edge branch coverage for src/merge/orphanCleanup.ts that the main
+// suite does not reach:
+//   - fileExists() non-ENOENT throw → read-failed entry (lines 254-262)
+//   - unlink ENOENT race → missing; unlink non-ENOENT → unlink-failed (289-294)
+//   - fileIsUserWrapped readFile rejects with a non-Error → String() branch
+//   - isPathInKnownAdapterRoot exact-file prefix match (line 147) and the
+//     rel === "" guard (line 139)
+//   - formatOrphanCleanupDiagnostic e.error ?? e.reason fallback (line 343)
+// ───────────────────────────────────────────────────────────────────────────
+
+async function fileExistsOnDisk(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (err) {
+    // Test probe: a missing path is the expected, non-actionable outcome.
+    void err;
+    return false;
+  }
+}
+
+describe("sweepOrphansForAdapter — fs error branches (mocked node:fs/promises)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-orphan-errb-"));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("marks a candidate read-failed when access() throws a NON-ENOENT error (EACCES)", async () => {
+    // fileExists() swallows ENOENT but rethrows other errnos; sweepOrphansForAdapter
+    // catches that rethrow and records a `read-failed` entry with the message.
+    const relPath = ".cursor/rules/hatch3r-perm.mdc";
+    await mkdir(join(tempDir, ".cursor", "rules"), { recursive: true });
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        access: vi.fn().mockRejectedValue(
+          Object.assign(new Error("permission denied"), { code: "EACCES" }),
+        ),
+      };
+    });
+
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    const entries = await sweepOrphansForAdapter("cursor", tempDir, [relPath], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("read-failed");
+    expect(entries[0].error).toContain("permission denied");
+  });
+
+  it("treats an ENOENT race on unlink as 'missing' (file vanished between exists-check and unlink)", async () => {
+    // File exists at the access() check, but unlink() races and reports ENOENT.
+    // The unlink catch maps ENOENT → missing (not unlink-failed).
+    const relPath = ".cursor/rules/hatch3r-race.mdc";
+    await mkdir(join(tempDir, ".cursor", "rules"), { recursive: true });
+    await writeFile(join(tempDir, relPath), "<!-- HATCH3R:BEGIN -->\nx\n<!-- HATCH3R:END -->\n");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        unlink: vi.fn().mockRejectedValue(
+          Object.assign(new Error("gone"), { code: "ENOENT" }),
+        ),
+      };
+    });
+
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    const entries = await sweepOrphansForAdapter("cursor", tempDir, [relPath], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("missing");
+  });
+
+  it("records 'unlink-failed' with the error message on a non-ENOENT unlink error (EACCES)", async () => {
+    const relPath = ".cursor/rules/hatch3r-locked.mdc";
+    await mkdir(join(tempDir, ".cursor", "rules"), { recursive: true });
+    await writeFile(join(tempDir, relPath), "<!-- HATCH3R:BEGIN -->\nx\n<!-- HATCH3R:END -->\n");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        unlink: vi.fn().mockRejectedValue(
+          Object.assign(new Error("EACCES: permission denied, unlink"), { code: "EACCES" }),
+        ),
+      };
+    });
+
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    const entries = await sweepOrphansForAdapter("cursor", tempDir, [relPath], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("unlink-failed");
+    expect(entries[0].error).toContain("permission denied");
+    // File still present (the unlink "failed").
+    expect(await fileExistsOnDisk(join(tempDir, relPath))).toBe(true);
+  });
+
+  it("records 'read-failed' when fileIsUserWrapped's readFile rejects with a NON-Error value (String() branch)", async () => {
+    // fileIsUserWrapped does `err instanceof Error ? err.message : String(err)`.
+    // Rejecting readFile with a plain object (not an Error) exercises the
+    // String() fall-through; the result surfaces as a read-failed entry whose
+    // `error` is the stringified value.
+    const relPath = ".cursor/rules/hatch3r-weird.mdc";
+    await mkdir(join(tempDir, ".cursor", "rules"), { recursive: true });
+    await writeFile(join(tempDir, relPath), "content");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        // access stays real so the exists-check passes; only readFile is poisoned.
+        readFile: vi.fn().mockRejectedValue({ toString: () => "non-error-read-failure" }),
+      };
+    });
+
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    const entries = await sweepOrphansForAdapter("cursor", tempDir, [relPath], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("read-failed");
+    expect(entries[0].error).toBe("non-error-read-failure");
+  });
+});
+
+describe("sweepOrphansForAdapter — isPathInKnownAdapterRoot exact-file + root edge cases", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-orphan-root-"));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("accepts an exact-file adapter-root prefix (CLAUDE.md), then rejects on the basename filter", async () => {
+    // CLAUDE.md is an exact-file prefix in TOOL_PATH_PREFIXES.claude, so
+    // isPathInKnownAdapterRoot returns true via the `posix === prefix` branch
+    // (line 147). The basename then fails the hatch3r-* check, yielding
+    // `not-managed-basename` — proving the root check passed but the basename
+    // soundness check still guards the unlink.
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    await writeFile(join(tempDir, "CLAUDE.md"), "# user managed file\n");
+
+    const entries = await sweepOrphansForAdapter("claude", tempDir, ["CLAUDE.md"], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("not-managed-basename");
+    // The exact-file root path was NOT rejected as outside-adapter-root.
+    expect(entries[0].reason).not.toBe("outside-adapter-root");
+  });
+
+  it("rejects the repo-root path itself ('.') as outside-adapter-root (rel === '' guard)", async () => {
+    // A manifest entry of "." resolves to rootDir; relative(rootDir, rootDir)
+    // is "", which the rel === "" guard rejects → not a file path.
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+
+    const entries = await sweepOrphansForAdapter("cursor", tempDir, ["."], []);
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].removed).toBe(false);
+    expect(entries[0].reason).toBe("outside-adapter-root");
+  });
+
+  it("accepts the copilot .vscode/mcp.json exact-file prefix (then basename-rejects)", async () => {
+    // Second distinct exact-file prefix to confirm the line-147 branch is not
+    // CLAUDE.md-specific.
+    const { sweepOrphansForAdapter } = await import("../../merge/orphanCleanup.js");
+    await mkdir(join(tempDir, ".vscode"), { recursive: true });
+    await writeFile(join(tempDir, ".vscode", "mcp.json"), "{}\n");
+
+    const entries = await sweepOrphansForAdapter(
+      "copilot",
+      tempDir,
+      [".vscode/mcp.json"],
+      [],
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0].reason).toBe("not-managed-basename");
+  });
+});
+
+describe("formatOrphanCleanupDiagnostic — error ?? reason fallback", () => {
+  it("falls back to the reason label when a failed entry has no error string", () => {
+    // The failed-section formatter uses `${e.error ?? e.reason}`. A
+    // unlink-failed / read-failed entry that somehow carries no `error` must
+    // still render — with the reason as the fallback label.
+    const msg = formatOrphanCleanupDiagnostic([
+      {
+        adapter: "cursor",
+        path: ".cursor/rules/hatch3r-x.mdc",
+        removed: false,
+        reason: "unlink-failed",
+        // no `error` field
+      },
+    ]);
+    expect(msg).toContain("Failed to remove 1 orphan candidate(s)");
+    expect(msg).toContain(".cursor/rules/hatch3r-x.mdc");
+    // Fallback label is the reason, since error is undefined.
+    expect(msg).toContain("unlink-failed");
+  });
+});

--- a/src/__tests__/merge/predictMergeAction.test.ts
+++ b/src/__tests__/merge/predictMergeAction.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { predictMergeAction } from "../../merge/safeWrite.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// predictMergeAction — pure (no I/O) MergeResult.action predictor used by
+// `hatch3r sync --dry-run` (D11-SA11.2-F9). Each test asserts the predicted
+// action vocabulary matches the documented safeWriteFile branch-for-branch
+// decision logic. The predictor MUST produce the same action a live write
+// would, so a dry-run preview does not diverge from the subsequent live sync.
+// ───────────────────────────────────────────────────────────────────────────
+
+const START = "<!-- HATCH3R:BEGIN -->";
+const END = "<!-- HATCH3R:END -->";
+
+describe("predictMergeAction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("absent file", () => {
+    it("predicts 'created' when existingContent is null (file does not exist)", () => {
+      expect(predictMergeAction(null, "new body", "AGENTS.md")).toBe("created");
+    });
+
+    it("predicts 'created' even with managedContent when file is absent", () => {
+      expect(
+        predictMergeAction(null, "x", "AGENTS.md", { managedContent: "m" }),
+      ).toBe("created");
+    });
+  });
+
+  describe("managedContent + existing file WITHOUT a managed block", () => {
+    it("predicts 'skipped' when appendIfNoBlock is absent (would-be-skip case)", () => {
+      const existing = "# user file with no markers\n";
+      expect(
+        predictMergeAction(existing, "", "AGENTS.md", { managedContent: "m" }),
+      ).toBe("skipped");
+    });
+
+    it("predicts 'updated' when appendIfNoBlock prepends new bytes", () => {
+      const existing = "# user content\n";
+      const action = predictMergeAction(existing, "managed body", "AGENTS.md", {
+        managedContent: "managed body",
+        appendIfNoBlock: true,
+      });
+      expect(action).toBe("updated");
+    });
+
+    it("predicts 'unchanged' when whitespace-only content makes the prepend a no-op", () => {
+      // The appendIfNoBlock 'unchanged' equality IS reachable, contrary to an
+      // earlier "prepended bytes are strictly longer than existing → unreachable"
+      // rationalization: when `content` trims to empty, the prepend
+      // `[content.trim(), "", existing.trimStart()].join("\n")` reduces to
+      // "\n\n" + existing.trimStart(). For an existing no-block file that is
+      // itself "\n\n" + trimmed-body + "\n", prepended === existing, so both this
+      // predictor (safeWrite.ts:578) and the live write (safeWrite.ts:689-690)
+      // return 'unchanged'. The live-path counterpart is covered in
+      // safeWrite.test.ts ("appendIfNoBlock with whitespace-only content ...").
+      const existing = "\n\nhello world\n";
+      const action = predictMergeAction(existing, "", "AGENTS.md", {
+        managedContent: "irrelevant-but-truthy",
+        appendIfNoBlock: true,
+      });
+      expect(action).toBe("unchanged");
+    });
+
+    it("predicts 'updated' even when skipIfUnchanged is false on the appendIfNoBlock path", () => {
+      // With skipIfUnchanged off, the 'unchanged' short-circuit (safeWrite.ts:578)
+      // is bypassed, so even a no-op prepend predicts 'updated' (the live write
+      // would re-emit byte-identical content rather than skip).
+      const existing = "# user content\n";
+      const action = predictMergeAction(existing, "managed body", "AGENTS.md", {
+        managedContent: "managed body",
+        appendIfNoBlock: true,
+        skipIfUnchanged: false,
+      });
+      expect(action).toBe("updated");
+    });
+  });
+
+  describe("managedContent + existing file WITH a managed block", () => {
+    it("predicts 'updated' when the merge changes bytes", () => {
+      const existing = `${START}\nold body\n${END}\n\n# user\n`;
+      const action = predictMergeAction(existing, "", "AGENTS.md", {
+        managedContent: "new body",
+      });
+      expect(action).toBe("updated");
+    });
+
+    it("predicts 'unchanged' when the merged bytes equal the existing file", () => {
+      // Build `existing` to be exactly what insertManagedBlock would produce for
+      // the same managedContent, so merged === existing → unchanged.
+      const existing = `${START}\nsame body\n${END}\n`;
+      const action = predictMergeAction(existing, "", "AGENTS.md", {
+        managedContent: "same body",
+      });
+      expect(action).toBe("unchanged");
+    });
+
+    it("predicts 'updated' for an unchanged merge when skipIfUnchanged is false", () => {
+      const existing = `${START}\nsame body\n${END}\n`;
+      const action = predictMergeAction(existing, "", "AGENTS.md", {
+        managedContent: "same body",
+        skipIfUnchanged: false,
+      });
+      expect(action).toBe("updated");
+    });
+
+    it("predicts 'updated' AND logs a diagnostic when the block is corrupted (live path auto-repairs)", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // Duplicate BEGIN markers → insertManagedBlock throws → predictor catches,
+      // emits the Silent-Failure diagnostic, and predicts 'updated' (auto-repair).
+      const corrupted = [START, "a", START, "dup", END].join("\n");
+
+      const action = predictMergeAction(corrupted, "", "x.md", {
+        managedContent: "new",
+      });
+
+      expect(action).toBe("updated");
+      expect(errorSpy).toHaveBeenCalled();
+      const msg = errorSpy.mock.calls.map((c) => String(c[0])).join(" ");
+      expect(msg).toContain("corrupted/duplicate");
+      expect(msg).toContain("x.md");
+      expect(msg).toContain("auto-repairs");
+    });
+  });
+
+  describe("no managedContent (whole-file replace path)", () => {
+    it("predicts 'updated' for a hatch3r-managed filename when bytes differ", () => {
+      expect(
+        predictMergeAction("old", "new", "hatch3r-rule.md"),
+      ).toBe("updated");
+    });
+
+    it("predicts 'unchanged' for a managed filename when bytes match", () => {
+      expect(
+        predictMergeAction("same", "same", "hatch3r-rule.md"),
+      ).toBe("unchanged");
+    });
+
+    it("predicts 'updated' for a managed filename with matching bytes when skipIfUnchanged is false", () => {
+      expect(
+        predictMergeAction("same", "same", "hatch3r-rule.md", { skipIfUnchanged: false }),
+      ).toBe("updated");
+    });
+
+    it("predicts 'updated' for a NN-hatch3r- prefixed filename", () => {
+      expect(
+        predictMergeAction("old", "new", ".cursor/rules/10-hatch3r-security.mdc"),
+      ).toBe("updated");
+    });
+
+    it("predicts 'updated' when force is set on a NON-managed filename", () => {
+      expect(
+        predictMergeAction("old user", "forced", "custom.md", { force: true }),
+      ).toBe("updated");
+    });
+
+    it("predicts 'unchanged' when force is set but bytes match", () => {
+      expect(
+        predictMergeAction("same", "same", "custom.md", { force: true }),
+      ).toBe("unchanged");
+    });
+
+    it("predicts 'skipped' for a non-managed filename without force", () => {
+      expect(predictMergeAction("user content", "new", "custom.md")).toBe("skipped");
+    });
+  });
+});

--- a/src/__tests__/merge/safeWrite.errorPaths.test.ts
+++ b/src/__tests__/merge/safeWrite.errorPaths.test.ts
@@ -145,6 +145,46 @@ describe("atomicWriteFile error paths", () => {
     });
   });
 
+  // ── FS_ERRNO_MESSAGE family (D8-SA8.2-F8.2.7) ──────────────────
+  // ENOSPC/EACCES are covered above. The remaining errno→actionable-message
+  // table entries (EDQUOT/EROFS/EFBIG/EMFILE/ENFILE/EIO) each map a write-side
+  // failure to a complete, cause-naming sentence routed through a FS_ERROR
+  // HatchError. Assert each distinct message AND the FS_ERROR code so a
+  // regression that dropped a table row (re-falling-through to a bare Node
+  // message) is caught.
+
+  describe("FS_ERRNO_MESSAGE actionable messages", () => {
+    const cases: Array<{ code: string; matcher: RegExp }> = [
+      { code: "EDQUOT", matcher: /Filesystem quota exceeded.*raise it/s },
+      { code: "EROFS", matcher: /Read-only filesystem.*remount read-write/s },
+      { code: "EFBIG", matcher: /File too large.*FAT32/s },
+      { code: "EMFILE", matcher: /Too many open files.*ulimit -n/s },
+      { code: "ENFILE", matcher: /System-wide open-file limit.*raise the system fd limit/s },
+      { code: "EIO", matcher: /Low-level I\/O error.*fsck/s },
+    ];
+
+    for (const { code, matcher } of cases) {
+      it(`maps ${code} to its actionable FS_ERROR message`, async () => {
+        mockWriteFile.mockRejectedValue(mkErrno(code));
+
+        await expect(atomicWriteFile("/some/dir/out.md", "data")).rejects.toMatchObject({
+          name: "HatchError",
+          errorCode: "FS_ERROR",
+        });
+        // Re-run to assert the message text (a thrown HatchError is consumed
+        // by the first rejects assertion).
+        await expect(atomicWriteFile("/some/dir/out.md", "data")).rejects.toThrow(matcher);
+      });
+    }
+
+    it("includes the target path in the EDQUOT message", async () => {
+      mockWriteFile.mockRejectedValue(mkErrno("EDQUOT"));
+      await expect(atomicWriteFile("/quota/dir/file.md", "x")).rejects.toThrow(
+        "/quota/dir/file.md",
+      );
+    });
+  });
+
   // ── fdatasync EPERM fallback ───────────────────────────────────
 
   describe("fdatasync EPERM fallback", () => {
@@ -155,6 +195,26 @@ describe("atomicWriteFile error paths", () => {
         atomicWriteFile("/tmp/test.txt", "data"),
       ).resolves.toBeUndefined();
 
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it("ignores ENOTSUP from datasync (network mount / FAT32)", async () => {
+      // The atomic rename provides the safety guarantee; datasync is
+      // best-effort durability, so an unsupported-operation errno is swallowed.
+      mockDatasync.mockRejectedValue(mkErrno("ENOTSUP"));
+
+      await expect(
+        atomicWriteFile("/tmp/test.txt", "data"),
+      ).resolves.toBeUndefined();
+      expect(mockClose).toHaveBeenCalled();
+    });
+
+    it("ignores EINVAL from datasync (filesystem rejects fdatasync)", async () => {
+      mockDatasync.mockRejectedValue(mkErrno("EINVAL"));
+
+      await expect(
+        atomicWriteFile("/tmp/test.txt", "data"),
+      ).resolves.toBeUndefined();
       expect(mockClose).toHaveBeenCalled();
     });
 
@@ -236,6 +296,24 @@ describe("atomicWriteFile error paths", () => {
         expect(msg).toContain("/tmp/test-diag.txt.tmp.");
         expect(msg).toContain("locked");
         expect(msg).toContain("orphan-tmp sweep");
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("stringifies a non-Error unlink rejection in the diagnostic (String() branch)", async () => {
+      // The diagnostic uses `unlinkErr instanceof Error ? .message : String(unlinkErr)`.
+      // Reject with a plain object (no .code, not an Error) to exercise the
+      // String() fall-through and confirm the diagnostic still surfaces.
+      mockUnlink.mockRejectedValue({ toString: () => "weird-non-error" });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await atomicWriteFile("/tmp/test-nonerr.txt", "data");
+        expect(errorSpy).toHaveBeenCalled();
+        const msg = errorSpy.mock.calls.map((c) => String(c[0])).join(" ");
+        expect(msg).toContain("failed to remove temp file");
+        expect(msg).toContain("weird-non-error");
       } finally {
         errorSpy.mockRestore();
       }
@@ -394,6 +472,125 @@ describe("safeWriteFile additional branches", () => {
           managedContent: "new managed",
         }),
       ).rejects.toThrow(/Backup verification failed.*Aborting auto-repair/);
+    });
+
+    it("throws on SHA-256 mismatch even when sizes match (partial-write/corruption guard)", async () => {
+      // D1-M12: size equality is necessary but not sufficient. Mock stat so the
+      // size check PASSES (equal sizes), then mock readFile of the .bak to
+      // return bytes whose SHA-256 differs from the source — exercising the
+      // hash-comparison abort branch the size check would miss.
+      vi.resetModules();
+
+      const mockCopyFile = vi
+        .fn<(...args: unknown[]) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      const mockStat = vi
+        .fn<(...args: unknown[]) => Promise<{ size: number }>>()
+        .mockResolvedValue({ size: 42 }); // equal sizes → size check passes
+
+      // readFile is called twice in the corruption path: (1) existingContent as
+      // utf-8 at the top of safeWriteFile, (2) the .bak bytes (no encoding) for
+      // hashing. Return DIFFERENT bytes for the bak read to force a hash mismatch.
+      const realFs = await vi.importActual<typeof import("node:fs/promises")>(
+        "node:fs/promises",
+      );
+      const mockReadFile = vi
+        .fn<(...args: unknown[]) => Promise<string | Buffer>>()
+        .mockImplementation(async (p: unknown, enc?: unknown) => {
+          if (enc === "utf-8") {
+            // The pre-repair source content read at the top of safeWriteFile.
+            return [
+              "<!-- HATCH3R:BEGIN -->",
+              "a",
+              "<!-- HATCH3R:BEGIN -->",
+              "dup",
+              "<!-- HATCH3R:END -->",
+            ].join("\n");
+          }
+          // The .bak byte read for hashing — deliberately divergent bytes.
+          return Buffer.from("totally different backup bytes");
+        });
+
+      vi.doMock("node:fs/promises", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("node:fs/promises")>();
+        return {
+          ...actual,
+          copyFile: mockCopyFile,
+          stat: mockStat,
+          readFile: mockReadFile,
+        };
+      });
+
+      const { safeWriteFile } = await import("../../merge/safeWrite.js");
+
+      const dir = await createTempDir();
+      const filePath = join(dir, "sha-mismatch.md");
+      // Real on-disk content so the initial fileExists() (uses access) succeeds.
+      await realFs.writeFile(
+        filePath,
+        ["<!-- HATCH3R:BEGIN -->", "a", "<!-- HATCH3R:BEGIN -->", "dup", "<!-- HATCH3R:END -->"].join(
+          "\n",
+        ),
+        "utf-8",
+      );
+
+      await expect(
+        safeWriteFile(filePath, "replacement", { managedContent: "new managed" }),
+      ).rejects.toThrow(/Backup verification failed.*SHA-256 mismatch/);
+
+      vi.doUnmock("node:fs/promises");
+      vi.resetModules();
+    });
+  });
+
+  describe("marker-variant auto-repair warning (D11-SA11.2-F11)", () => {
+    it("emits an 'Auto-repaired marker syntax' warning when a .yml file has HTML markers", async () => {
+      // A .yml output written by a pre-#76 hatch3r carries HTML <!-- --> markers.
+      // The next sync detects the wrong-variant block, rewrites it to YAML `#`
+      // markers, and surfaces a one-line warning on the MergeResult.warning
+      // channel so the on-disk byte change is attributable (not a silent git diff).
+      const { safeWriteFile } = await import("../../merge/safeWrite.js");
+
+      const dir = await createTempDir();
+      const filePath = join(dir, "copilot-setup-steps.yml");
+      const existing = [
+        "<!-- HATCH3R:BEGIN -->",
+        "old: value",
+        "<!-- HATCH3R:END -->",
+        "",
+        "user_key: kept",
+      ].join("\n");
+      await writeFile(filePath, existing, "utf-8");
+
+      const result = await safeWriteFile(filePath, "", { managedContent: "new: value" });
+
+      expect(result.action).toBe("updated");
+      expect(result.warning).toContain("Auto-repaired marker syntax");
+      expect(result.warning).toContain(filePath);
+
+      // The on-disk file now carries YAML markers, not HTML, and user content
+      // outside the block is preserved.
+      const onDisk = await readFile(filePath, "utf-8");
+      expect(onDisk).toContain("# HATCH3R:BEGIN");
+      expect(onDisk).not.toContain("<!--");
+      expect(onDisk).toContain("new: value");
+      expect(onDisk).toContain("user_key: kept");
+    });
+
+    it("does NOT emit a variant warning when markers already match the file type", async () => {
+      // Same-variant merge (markdown file with HTML markers) → no auto-repair
+      // warning; the variantChanged branch is false.
+      const { safeWriteFile } = await import("../../merge/safeWrite.js");
+
+      const dir = await createTempDir();
+      const filePath = join(dir, "AGENTS.md");
+      const existing = ["<!-- HATCH3R:BEGIN -->", "old", "<!-- HATCH3R:END -->"].join("\n");
+      await writeFile(filePath, existing, "utf-8");
+
+      const result = await safeWriteFile(filePath, "", { managedContent: "fresh" });
+
+      expect(result.action).toBe("updated");
+      expect(result.warning).toBeUndefined();
     });
   });
 

--- a/src/__tests__/merge/safeWrite.lockBranches.test.ts
+++ b/src/__tests__/merge/safeWrite.lockBranches.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Lock-path branch coverage for src/merge/safeWrite.ts that the real-fs
+// fileLock suite cannot reach deterministically:
+//   - acquireWriteLock reentrancy (HELD_LOCKS short-circuit, line 177)
+//   - acquireWriteLock non-ELOCKED error rethrow (line 216)
+//   - atomicWriteFile release()-throws diagnostic when locking active (356-357)
+//   - resolveLockStaleMs env-var parsing branches (75-77)
+//
+// These mock `proper-lockfile` so the lock primitive returns a controllable
+// release function (and can be made to throw arbitrary errors).
+// ───────────────────────────────────────────────────────────────────────────
+
+function mkErrno(code: string, message = ""): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error(message || code);
+  err.code = code;
+  return err;
+}
+
+describe("acquireWriteLock — reentrancy and non-ELOCKED errors (mocked proper-lockfile)", () => {
+  let tempDir: string;
+  const origLock = process.env.HATCH3R_LOCK;
+  const mockLock = vi.fn<(...args: unknown[]) => Promise<() => Promise<void>>>();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-lockbranch-"));
+
+    vi.doMock("proper-lockfile", () => ({
+      lock: mockLock,
+    }));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    if (origLock === undefined) delete process.env.HATCH3R_LOCK;
+    else process.env.HATCH3R_LOCK = origLock;
+    vi.doUnmock("proper-lockfile");
+    vi.resetModules();
+  });
+
+  it("is reentrant within one process — a nested acquire on a held path returns a no-op release", async () => {
+    process.env.HATCH3R_LOCK = "1";
+    const release = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    mockLock.mockResolvedValue(release);
+
+    const { acquireWriteLock } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "reentrant.md");
+
+    // Outer acquire takes the real on-disk lock exactly once.
+    const releaseOuter = await acquireWriteLock(filePath);
+    // Inner acquire for the SAME path must NOT call proper-lockfile again —
+    // it short-circuits to a no-op release so the outer holder owns the cycle.
+    const releaseInner = await acquireWriteLock(filePath);
+
+    expect(mockLock).toHaveBeenCalledTimes(1);
+
+    // Releasing the inner no-op must NOT release the real lock.
+    await releaseInner();
+    expect(release).not.toHaveBeenCalled();
+
+    // Releasing the outer releases the real proper-lockfile lock.
+    await releaseOuter();
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows a non-ELOCKED error from proper-lockfile unchanged (not wrapped as LOCK_TIMEOUT)", async () => {
+    process.env.HATCH3R_LOCK = "1";
+    // proper-lockfile can surface filesystem errors (e.g. EACCES creating the
+    // lockfile). Only ELOCKED is translated to LOCK_TIMEOUT; everything else
+    // must propagate verbatim so the operator sees the real cause.
+    mockLock.mockRejectedValue(mkErrno("EACCES", "cannot create lockfile"));
+
+    const { acquireWriteLock } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "lock-eacces.md");
+
+    await expect(acquireWriteLock(filePath)).rejects.toMatchObject({
+      code: "EACCES",
+      message: "cannot create lockfile",
+    });
+    // It must NOT have been rewrapped into a HatchError/LOCK_TIMEOUT.
+    await expect(acquireWriteLock(filePath)).rejects.not.toMatchObject({
+      errorCode: "LOCK_TIMEOUT",
+    });
+  });
+
+  it("translates ELOCKED to a LOCK_TIMEOUT HatchError (via the mocked lock)", async () => {
+    process.env.HATCH3R_LOCK = "1";
+    mockLock.mockRejectedValue(mkErrno("ELOCKED", "held"));
+
+    const { acquireWriteLock } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "lock-elocked.md");
+
+    await expect(acquireWriteLock(filePath)).rejects.toMatchObject({
+      name: "HatchError",
+      errorCode: "LOCK_TIMEOUT",
+    });
+  });
+});
+
+describe("atomicWriteFile — release() failure diagnostic (mocked proper-lockfile)", () => {
+  let tempDir: string;
+  const origLock = process.env.HATCH3R_LOCK;
+  const mockLock = vi.fn<(...args: unknown[]) => Promise<() => Promise<void>>>();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-lockrel-"));
+    vi.doMock("proper-lockfile", () => ({ lock: mockLock }));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    if (origLock === undefined) delete process.env.HATCH3R_LOCK;
+    else process.env.HATCH3R_LOCK = origLock;
+    vi.doUnmock("proper-lockfile");
+    vi.resetModules();
+  });
+
+  it("emits a console.error diagnostic (and does NOT throw) when release() rejects while locking is active", async () => {
+    process.env.HATCH3R_LOCK = "1";
+    // The lock is acquired fine, the write succeeds, but releasing the lock in
+    // the finally block throws. Per the Silent Failure Contract the original
+    // operation must still succeed and the release failure must be logged.
+    const release = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue(new Error("release boom"));
+    mockLock.mockResolvedValue(release);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { atomicWriteFile } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "release-fail.md");
+
+    try {
+      // Must NOT reject — the write itself succeeded; only the release failed.
+      await expect(atomicWriteFile(filePath, "ok content")).resolves.toBeUndefined();
+
+      // File was written correctly.
+      expect(await readFile(filePath, "utf-8")).toBe("ok content");
+
+      // Diagnostic surfaced because locking was active for this call.
+      expect(errorSpy).toHaveBeenCalled();
+      const msg = errorSpy.mock.calls.map((c) => String(c[0])).join(" ");
+      expect(msg).toContain("failed to release write lock");
+      expect(msg).toContain(filePath);
+      expect(msg).toContain("release boom");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("stringifies a non-Error release rejection in the release diagnostic", async () => {
+    process.env.HATCH3R_LOCK = "1";
+    // releaseErr instanceof Error ? .message : String(releaseErr) — exercise
+    // the String() branch by rejecting the release with a non-Error value.
+    const release = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValue("plain-string-rejection");
+    mockLock.mockResolvedValue(release);
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { atomicWriteFile } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "release-fail-2.md");
+
+    try {
+      await atomicWriteFile(filePath, "content");
+      const msg = errorSpy.mock.calls.map((c) => String(c[0])).join(" ");
+      expect(msg).toContain("failed to release write lock");
+      expect(msg).toContain("plain-string-rejection");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});
+
+describe("resolveLockStaleMs env-var parsing (HATCH3R_LOCK_STALE_MS, mocked proper-lockfile)", () => {
+  // resolveLockStaleMs is module-internal; observe its result via the `stale`
+  // option passed to the mocked proper-lockfile.lock. Each env value drives a
+  // distinct branch: undefined/blank → default; non-finite/≤0 → default;
+  // valid-large → that value; sub-floor → clamped up to the floor.
+  let tempDir: string;
+  const origLock = process.env.HATCH3R_LOCK;
+  const origStale = process.env.HATCH3R_LOCK_STALE_MS;
+  const mockLock = vi.fn<(...args: unknown[]) => Promise<() => Promise<void>>>();
+
+  const DEFAULT_MS = 15_000;
+  const FLOOR_MS = 2_000;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-stale-"));
+    const release = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    mockLock.mockResolvedValue(release);
+    vi.doMock("proper-lockfile", () => ({ lock: mockLock }));
+    process.env.HATCH3R_LOCK = "1";
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    if (origLock === undefined) delete process.env.HATCH3R_LOCK;
+    else process.env.HATCH3R_LOCK = origLock;
+    if (origStale === undefined) delete process.env.HATCH3R_LOCK_STALE_MS;
+    else process.env.HATCH3R_LOCK_STALE_MS = origStale;
+    vi.doUnmock("proper-lockfile");
+    vi.resetModules();
+  });
+
+  async function acquireAndReadStale(): Promise<number> {
+    // Re-import fresh so the env var is read at call time (resolveLockStaleMs
+    // reads process.env on each acquire).
+    const { acquireWriteLock } = await import("../../merge/safeWrite.js");
+    const release = await acquireWriteLock(join(tempDir, `f-${Math.random()}.md`));
+    await release();
+    const lastCall = mockLock.mock.calls.at(-1);
+    const opts = lastCall?.[1] as { stale: number };
+    return opts.stale;
+  }
+
+  it("uses the 15s default when HATCH3R_LOCK_STALE_MS is unset", async () => {
+    delete process.env.HATCH3R_LOCK_STALE_MS;
+    expect(await acquireAndReadStale()).toBe(DEFAULT_MS);
+  });
+
+  it("uses the default when HATCH3R_LOCK_STALE_MS is blank/whitespace", async () => {
+    process.env.HATCH3R_LOCK_STALE_MS = "   ";
+    expect(await acquireAndReadStale()).toBe(DEFAULT_MS);
+  });
+
+  it("falls back to the default for a non-numeric value", async () => {
+    process.env.HATCH3R_LOCK_STALE_MS = "not-a-number";
+    expect(await acquireAndReadStale()).toBe(DEFAULT_MS);
+  });
+
+  it("falls back to the default for a non-positive value (0 / negative)", async () => {
+    process.env.HATCH3R_LOCK_STALE_MS = "0";
+    expect(await acquireAndReadStale()).toBe(DEFAULT_MS);
+    process.env.HATCH3R_LOCK_STALE_MS = "-500";
+    expect(await acquireAndReadStale()).toBe(DEFAULT_MS);
+  });
+
+  it("honours a valid large override above the floor (truncated to integer)", async () => {
+    process.env.HATCH3R_LOCK_STALE_MS = "30000.9";
+    // Math.trunc → 30000, which is >= floor so used as-is.
+    expect(await acquireAndReadStale()).toBe(30_000);
+  });
+
+  it("clamps a sub-floor positive value up to the 2s floor", async () => {
+    process.env.HATCH3R_LOCK_STALE_MS = "500";
+    expect(await acquireAndReadStale()).toBe(FLOOR_MS);
+  });
+});

--- a/src/__tests__/merge/safeWrite.sweepBranches.test.ts
+++ b/src/__tests__/merge/safeWrite.sweepBranches.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { formatOrphanTmpSweepDiagnostic } from "../../merge/safeWrite.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Remaining branch coverage for src/merge/safeWrite.ts:
+//   - safeWriteFile fileExists() non-ENOENT rethrow (line 31 catch in fileExists)
+//   - sweepOrphanTmpFiles Dirent parent-path fallbacks (parentPath ?? path ?? dir)
+//   - sweepOrphanTmpFiles readdir/unlink non-Error rejection String() branches
+//   - formatOrphanTmpSweepDiagnostic `error ?? "unknown"` fallback
+// ───────────────────────────────────────────────────────────────────────────
+
+describe("safeWriteFile — fileExists non-ENOENT propagation (mocked access)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-existserr-"));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("propagates a non-ENOENT error from access() (e.g. EACCES) instead of treating the file as absent", async () => {
+    // fileExists() returns false only for ENOENT; any other errno rethrows.
+    // safeWriteFile then surfaces that error rather than silently proceeding
+    // down the create path against an inaccessible target.
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        // mkdir must still succeed (called before fileExists in safeWriteFile).
+        access: vi.fn().mockRejectedValue(
+          Object.assign(new Error("permission denied"), { code: "EACCES" }),
+        ),
+      };
+    });
+
+    const { safeWriteFile } = await import("../../merge/safeWrite.js");
+    const filePath = join(tempDir, "inaccessible.md");
+
+    await expect(safeWriteFile(filePath, "content")).rejects.toMatchObject({
+      code: "EACCES",
+    });
+  });
+});
+
+describe("sweepOrphanTmpFiles — Dirent parent fallbacks + non-Error rejections (mocked node:fs/promises)", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-sweepb-"));
+  });
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    vi.doUnmock("node:fs/promises");
+    vi.resetModules();
+  });
+
+  it("falls back to `dir` for the parent when a Dirent exposes neither parentPath nor path", async () => {
+    // The parent resolution is `parentPath ?? path ?? dir`. Older Node Dirent
+    // shapes (or non-standard fs impls) may expose neither field; the sweep
+    // must then join against the scanned `dir`. We hand readdir a synthetic
+    // Dirent lacking both, plus a real aged orphan reachable at `dir`.
+    const orphanName = "target.md.tmp.deadbeef";
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        readdir: vi.fn().mockResolvedValue([
+          // No parentPath, no path — forces the `?? dir` fallback.
+          { name: orphanName, isFile: () => true },
+        ]),
+        // stat returns an aged mtime so the orphan passes the 60s gate.
+        stat: vi.fn().mockResolvedValue({ mtimeMs: Date.now() - 600_000 }),
+        unlink: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    const { sweepOrphanTmpFiles } = await import("../../merge/safeWrite.js");
+    const result = await sweepOrphanTmpFiles(tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].removed).toBe(true);
+    // Parent fell back to `dir`, so the reported path is dir/orphanName.
+    expect(result[0].path).toBe(join(tempDir, orphanName));
+  });
+
+  it("uses a Dirent `path` field as the parent when parentPath is absent", async () => {
+    // The middle fallback: `parentPath ?? path`. Provide only `path`.
+    const orphanName = "x.md.tmp.0badf00d";
+    const customParent = join(tempDir, "nested");
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        readdir: vi.fn().mockResolvedValue([
+          { name: orphanName, isFile: () => true, path: customParent },
+        ]),
+        stat: vi.fn().mockResolvedValue({ mtimeMs: Date.now() - 600_000 }),
+        unlink: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    const { sweepOrphanTmpFiles } = await import("../../merge/safeWrite.js");
+    const result = await sweepOrphanTmpFiles(tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe(join(customParent, orphanName));
+  });
+
+  it("stringifies a NON-Error readdir rejection in the diagnostic (String() branch) and returns []", async () => {
+    // readdir catch: `err instanceof Error ? err.message : String(err)`.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        // Plain object (no .code → not ENOENT, not an Error) → diagnostic via String().
+        readdir: vi.fn().mockRejectedValue({ toString: () => "weird-readdir-failure" }),
+      };
+    });
+
+    try {
+      const { sweepOrphanTmpFiles } = await import("../../merge/safeWrite.js");
+      const result = await sweepOrphanTmpFiles(tempDir);
+      expect(result).toEqual([]);
+      expect(errorSpy).toHaveBeenCalled();
+      const msg = errorSpy.mock.calls.map((c) => String(c[0])).join(" ");
+      expect(msg).toContain("orphan-tmp sweep could not read");
+      expect(msg).toContain("weird-readdir-failure");
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("stringifies a NON-Error unlink rejection in the sweep entry error (String() branch)", async () => {
+    // unlink catch in the per-file loop: `unlinkErr instanceof Error ? .message : String(...)`.
+    const orphanName = "stuck.md.tmp.cafebabe";
+
+    vi.doMock("node:fs/promises", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("node:fs/promises")>();
+      return {
+        ...actual,
+        readdir: vi.fn().mockResolvedValue([
+          { name: orphanName, isFile: () => true, parentPath: tempDir },
+        ]),
+        stat: vi.fn().mockResolvedValue({ mtimeMs: Date.now() - 600_000 }),
+        unlink: vi.fn().mockRejectedValue({ toString: () => "non-error-unlink" }),
+      };
+    });
+
+    const { sweepOrphanTmpFiles } = await import("../../merge/safeWrite.js");
+    const result = await sweepOrphanTmpFiles(tempDir);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].removed).toBe(false);
+    expect(result[0].error).toBe("non-error-unlink");
+  });
+});
+
+describe("formatOrphanTmpSweepDiagnostic — unknown-error fallback", () => {
+  it("renders 'unknown' for a failed entry that carries no error string", async () => {
+    // The failed-section formatter uses `${e.error ?? "unknown"}`.
+    const msg = formatOrphanTmpSweepDiagnostic([
+      { path: "/tmp/x.md.tmp.ffffffff", mtimeMs: 0, removed: false },
+    ]);
+    expect(msg).toContain("Failed to remove 1 orphan temp file");
+    expect(msg).toContain("/tmp/x.md.tmp.ffffffff");
+    expect(msg).toContain("unknown");
+  });
+});

--- a/src/__tests__/merge/safeWrite.test.ts
+++ b/src/__tests__/merge/safeWrite.test.ts
@@ -628,6 +628,32 @@ describe("safeWrite", () => {
       expect(second.action).toBe("unchanged");
     });
 
+    it("appendIfNoBlock with whitespace-only content is a no-op prepend → 'unchanged', disk untouched (safeWrite.ts:690)", async () => {
+      // safeWrite.ts:690 (the appendIfNoBlock 'unchanged' short-circuit) IS
+      // reachable on a FIRST write, not only on a redundant second sync: when
+      // `content` trims to empty, the prepend `[content.trim(), "",
+      // existing.trimStart()].join("\n")` reduces to "\n\n" + existing.trimStart().
+      // For an existing no-block file that is itself "\n\n" + trimmed-body + "\n",
+      // the prepended bytes equal the existing bytes, so the equality at
+      // safeWrite.ts:689 holds and line 690 returns 'unchanged' without writing.
+      // `managedContent` only needs to be truthy to pass the line-659 gate; it is
+      // not used in the prepend math (only the positional `content` arg is).
+      const dir = await createTempDir();
+      const filePath = join(dir, "AGENTS.md");
+      const existing = "\n\nhello world\n";
+      await writeFile(filePath, existing, "utf-8");
+
+      const result = await safeWriteFile(filePath, "", {
+        managedContent: "irrelevant-but-truthy",
+        appendIfNoBlock: true,
+      });
+
+      expect(result.action).toBe("unchanged");
+      expect(result.warning).toBeUndefined();
+      // Disk must be byte-identical to the pre-write content (no atomicWriteFile).
+      expect(await readFile(filePath, "utf-8")).toBe(existing);
+    });
+
     it("idempotent: hatch3r- prefix without managedContent — second write is unchanged", async () => {
       const dir = await createTempDir();
       const filePath = join(dir, "hatch3r-rule.md");

--- a/src/__tests__/migration/agentsToHatch3r.test.ts
+++ b/src/__tests__/migration/agentsToHatch3r.test.ts
@@ -316,10 +316,13 @@ describe("migrateAgentsToHatch3r — agents -> hatch3r migration shim", () => {
       const result = await migrateAgentsToHatch3r(tempDir);
 
       expect(result.conflicts).toHaveLength(2);
+      // sourcePath is rendered forward-slash on every platform (see
+      // agentsToHatch3r.ts::toDisplayPath); keep both expectations in the
+      // same convention so the assertion holds on Windows as well as POSIX.
       const sources = result.conflicts.map((c) => c.sourcePath).sort();
       expect(sources).toEqual([
         `${AGENTS_DIR}/${MANIFEST_FILE}`,
-        join(AGENTS_DIR, "mcp", "mcp.json"),
+        `${AGENTS_DIR}/mcp/mcp.json`,
       ]);
       // Conflicts keep the legacy directory in place.
       expect(result.removedLegacyDir).toBe(false);

--- a/src/__tests__/pipeline/checkpoint.test.ts
+++ b/src/__tests__/pipeline/checkpoint.test.ts
@@ -36,7 +36,13 @@ describe("pipeline/checkpoint", () => {
 
   describe("checkpointPath", () => {
     it("returns workspace/checkpoint.json", () => {
-      expect(checkpointPath("/tmp/foo")).toBe(`/tmp/foo/${CHECKPOINT_FILE}`);
+      // checkpointPath is an internal FS-path helper (fed to readFile/writeFile/
+      // copyFile), not a cross-platform persisted or user-facing `/`-path — so it
+      // correctly uses path.join and emits the native separator. Build the
+      // expected with join() too so the assertion is about composition, not the
+      // platform separator (`\` on Windows vs `/` on POSIX).
+      const workspace = join("/tmp", "foo");
+      expect(checkpointPath(workspace)).toBe(join(workspace, CHECKPOINT_FILE));
     });
   });
 

--- a/src/__tests__/pipeline/costEstimator.test.ts
+++ b/src/__tests__/pipeline/costEstimator.test.ts
@@ -2,7 +2,23 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock node:fs so the Silent Failure Contract tests can inject a write failure
+// at the fs boundary deterministically on every OS. Every call delegates to the
+// real implementation by default; individual tests override `mockMkdirSync`
+// to throw. (The prior tests pointed `projectRoot` at `/dev/null/<x>`, which
+// fails ENOTDIR on POSIX but can mkdir-succeed under a drive root on Windows —
+// making the assertion platform-dependent.)
+const realNodeFs = await vi.importActual<typeof import("node:fs")>("node:fs");
+const mockMkdirSync = vi.fn<typeof realNodeFs.mkdirSync>();
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    mkdirSync: (...a: Parameters<typeof actual.mkdirSync>) => mockMkdirSync(...a),
+  };
+});
 
 import {
   appendTelemetrySnapshot,
@@ -207,6 +223,13 @@ describe("computeDelta", () => {
 
 // ── recordActuals + appendTelemetrySnapshot persistence ─────────
 
+// Default: the mocked mkdirSync delegates to the real implementation. Failure
+// tests override it for their duration; this re-establishes the delegate before
+// every test so the override never leaks.
+beforeEach(() => {
+  mockMkdirSync.mockImplementation((...a) => realNodeFs.mkdirSync(...a));
+});
+
 describe("recordActuals", () => {
   let tmpRoot: string;
 
@@ -269,12 +292,17 @@ describe("recordActuals", () => {
   });
 
   it("returns false (no throw) when the project root is unwritable (Silent Failure Contract)", () => {
-    // /dev/null cannot host a .hatch3r/telemetry/ subtree.
+    // Inject the write failure at the fs boundary (mkdirSync throws) rather than
+    // via a POSIX-only unwritable path. `/dev/null/<x>` fails ENOTDIR on POSIX
+    // but resolves to a drive-relative `\dev\null\<x>` on Windows where mkdir can
+    // SUCCEED, making the assertion platform-dependent. This exercises the same
+    // Silent Failure Contract branch (catch → route → return false) on every OS.
+    mockMkdirSync.mockImplementation(() => {
+      throw Object.assign(new Error("mkdir denied"), { code: "EACCES" });
+    });
     let ok: boolean | undefined;
     expect(() => {
-      ok = recordActuals("oom-test", sampleActuals, {
-        projectRoot: "/dev/null/not-a-directory",
-      });
+      ok = recordActuals("oom-test", sampleActuals, { projectRoot: tmpRoot });
     }).not.toThrow();
     expect(ok).toBe(false);
   });
@@ -314,11 +342,14 @@ describe("appendTelemetrySnapshot", () => {
   it("returns true on successful write and false on failure", () => {
     const ok = appendTelemetrySnapshot("ok-session", { phase: "act" }, tmpRoot);
     expect(ok).toBe(true);
-    const fail = appendTelemetrySnapshot(
-      "fail-session",
-      { phase: "act" },
-      "/dev/null/not-a-dir",
-    );
+    // Inject the failure at the fs boundary (mkdirSync throws) instead of a
+    // POSIX-only `/dev/null/<x>` path: that path fails ENOTDIR on POSIX but can
+    // mkdir-succeed under a drive root on Windows. This drives the same catch →
+    // route → return-false branch on every OS.
+    mockMkdirSync.mockImplementation(() => {
+      throw Object.assign(new Error("mkdir denied"), { code: "EACCES" });
+    });
+    const fail = appendTelemetrySnapshot("fail-session", { phase: "act" }, tmpRoot);
     expect(fail).toBe(false);
   });
 

--- a/src/__tests__/pipeline/snapshot.errorPaths.test.ts
+++ b/src/__tests__/pipeline/snapshot.errorPaths.test.ts
@@ -1,0 +1,1043 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Error-path + defensive-branch coverage for src/pipeline/snapshot.ts, mirroring
+// the node:fs/promises mock approach in
+// src/__tests__/audit/archive.coldpack.errorPaths.test.ts.
+//
+// Every mocked fs call delegates to the REAL implementation by default (so the
+// function runs against a real tmpdir), and each test surgically overrides one
+// call to inject the fault that drives a specific defensive branch. The
+// real-fs round-trip and happy-path behavior is exercised in the sibling
+// snapshot.test.ts; this file pins the branches a clean real-fs run cannot
+// reach:
+//   - pruneSnapshots count-cap / byte-cap eviction + corrupt-meta onPrune +
+//     prune-failure routing (createSnapshot retention sweep, D6-SA6.4-F5)
+//   - removeSessionDir / dirSizeBytes recursion + mid-walk vanish skip
+//   - mirrorRelativePath defensive ".." traversal HatchError
+//   - withSnapshot environmental-failure downgrade (mutator still runs,
+//     sessionId null) vs programming-bug propagation
+//   - listSnapshots DEBUG diagnostic on an unreadable meta
+//   - applyRollback prepare-phase stat/EACCES/read branches
+//   - applyRollback commit-phase failure + roll-forward (rolled-forward,
+//     unknown dispositions, roll-forward write failure)
+// ---------------------------------------------------------------------------
+
+function mkErrno(code: string, message = ""): NodeJS.ErrnoException {
+  const err: NodeJS.ErrnoException = new Error(message || code);
+  err.code = code;
+  return err;
+}
+
+// Real modules captured once; the mock factories delegate to them.
+const realFs = await vi.importActual<typeof import("node:fs/promises")>(
+  "node:fs/promises",
+);
+const realPath = await vi.importActual<typeof import("node:path")>("node:path");
+
+const mockStat = vi.fn<typeof realFs.stat>();
+const mockReadFile = vi.fn<typeof realFs.readFile>();
+const mockUnlink = vi.fn<typeof realFs.unlink>();
+const mockRmdir = vi.fn<typeof realFs.rmdir>();
+const mockAccess = vi.fn<typeof realFs.access>();
+const mockMkdir = vi.fn<typeof realFs.mkdir>();
+const mockRename = vi.fn<typeof realFs.rename>();
+const mockReaddir = vi.fn<typeof realFs.readdir>();
+const mockRelative = vi.fn<typeof realPath.relative>();
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    stat: (...a: Parameters<typeof actual.stat>) => mockStat(...a),
+    readFile: (...a: Parameters<typeof actual.readFile>) => mockReadFile(...a),
+    unlink: (...a: Parameters<typeof actual.unlink>) => mockUnlink(...a),
+    rmdir: (...a: Parameters<typeof actual.rmdir>) => mockRmdir(...a),
+    access: (...a: Parameters<typeof actual.access>) => mockAccess(...a),
+    mkdir: (...a: Parameters<typeof actual.mkdir>) => mockMkdir(...a),
+    rename: (...a: Parameters<typeof actual.rename>) => mockRename(...a),
+    readdir: (...a: Parameters<typeof actual.readdir>) => mockReaddir(...a),
+  };
+});
+
+vi.mock("node:path", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:path")>();
+  return {
+    ...actual,
+    relative: (...a: Parameters<typeof actual.relative>) => mockRelative(...a),
+  };
+});
+
+const {
+  applyRollback,
+  createSnapshot,
+  listSnapshots,
+  withSnapshot,
+  sessionDir,
+  snapshotsRoot,
+  SNAPSHOT_FILES_DIR,
+  SNAPSHOT_META_FILE,
+  SNAPSHOT_SCHEMA_VERSION,
+  MAX_SNAPSHOT_COUNT,
+} = await import("../../pipeline/snapshot.js");
+
+/* eslint-disable silent-failure/no-silent-catch -- test existence probe. */
+async function exists(p: string): Promise<boolean> {
+  try {
+    await realFs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+/* eslint-enable silent-failure/no-silent-catch */
+
+/** Write a minimal-but-valid meta.json into a hand-seeded session dir. */
+async function seedSession(
+  projectRoot: string,
+  sessionId: string,
+  timestamp: string,
+  opts: { paths?: string[]; relativePaths?: string[]; rawMeta?: string } = {},
+): Promise<string> {
+  const dir = sessionDir(sessionId, projectRoot);
+  await realFs.mkdir(join(dir, SNAPSHOT_FILES_DIR), { recursive: true });
+  const raw =
+    opts.rawMeta ??
+    JSON.stringify({
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+      sessionId,
+      timestamp,
+      paths: opts.paths ?? [],
+      relativePaths: opts.relativePaths ?? [],
+      projectRoot,
+    });
+  await realFs.writeFile(join(dir, SNAPSHOT_META_FILE), raw);
+  return dir;
+}
+
+describe("pipeline/snapshot — error paths and defensive branches", () => {
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    vi.restoreAllMocks();
+    // Default: delegate every mocked call to the real implementation.
+    mockStat.mockImplementation((...a) => realFs.stat(...a));
+    mockReadFile.mockImplementation((...a) => realFs.readFile(...a));
+    mockUnlink.mockImplementation((...a) => realFs.unlink(...a));
+    mockRmdir.mockImplementation((...a) => realFs.rmdir(...a));
+    mockAccess.mockImplementation((...a) => realFs.access(...a));
+    mockMkdir.mockImplementation((...a) => realFs.mkdir(...a));
+    mockRename.mockImplementation((...a) => realFs.rename(...a));
+    mockReaddir.mockImplementation((...a) => realFs.readdir(...a));
+    mockRelative.mockImplementation((...a) => realPath.relative(...a));
+    delete process.env.DEBUG;
+    projectRoot = await realFs.mkdtemp(join(tmpdir(), "hatch3r-snap-err-"));
+  });
+
+  /* eslint-disable silent-failure/no-silent-catch -- tmpdir reap is best-effort. */
+  afterEach(async () => {
+    delete process.env.DEBUG;
+    try {
+      await realFs.rm(projectRoot, { recursive: true, force: true });
+    } catch {
+      // OS reaps tmpdir eventually.
+    }
+  });
+  /* eslint-enable silent-failure/no-silent-catch */
+
+  // ── pruneSnapshots: count cap (D6-SA6.4-F5) ──────────────────────────
+  describe("retention prune — count cap", () => {
+    it("evicts the oldest sessions over MAX_SNAPSHOT_COUNT and routes a count-cap prune message", async () => {
+      // Seed exactly MAX_SNAPSHOT_COUNT pre-existing sessions, oldest→newest by
+      // ISO timestamp. A fresh createSnapshot then pushes the store to
+      // MAX_SNAPSHOT_COUNT + 1, so the single oldest seeded session is pruned.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const ts = `2026-01-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(
+          i,
+        ).padStart(3, "0")}Z`;
+        await seedSession(projectRoot, `seed-${String(i).padStart(3, "0")}`, ts);
+      }
+      const oldest = sessionDir("seed-000", projectRoot);
+      expect(await exists(oldest)).toBe(true);
+
+      const fileA = join(projectRoot, "fresh.txt");
+      await realFs.writeFile(fileA, "fresh");
+      const prunes: string[] = [];
+      const result = await createSnapshot("fresh-capture", [fileA], {
+        projectRoot,
+        onWarn: (m) => prunes.push(m),
+      });
+
+      // The capture itself succeeds.
+      expect(result.count).toBe(1);
+      // The oldest seeded session was removed (removeSessionDir ran).
+      expect(await exists(oldest)).toBe(false);
+      // The just-captured session is never pruned.
+      expect(await exists(result.snapshotPath)).toBe(true);
+      // Exactly one count-cap prune message routed through onWarn.
+      const countCap = prunes.filter((m) => m.includes(`count cap ${MAX_SNAPSHOT_COUNT}`));
+      expect(countCap).toHaveLength(1);
+      expect(countCap[0]).toContain("Pruned old snapshot session seed-000");
+      expect(countCap[0]).toContain("rollback --session=seed-000");
+    });
+
+    it("sorts an unparseable-meta session oldest and surfaces a corrupt-meta diagnostic before pruning it", async () => {
+      // One corrupt session (empty timestamp → sorts oldest) plus enough valid
+      // sessions to breach the count cap so the prune loop actually runs.
+      await seedSession(projectRoot, "corrupt-001", "ignored", {
+        rawMeta: "{not valid json",
+      });
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        await seedSession(
+          projectRoot,
+          `ok-${String(i).padStart(3, "0")}`,
+          `2027-02-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+        );
+      }
+      const fileA = join(projectRoot, "x.txt");
+      await realFs.writeFile(fileA, "x");
+      const msgs: string[] = [];
+      await createSnapshot("cap-trigger", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+
+      // The corrupt session sorted oldest and was reclaimed first.
+      expect(await exists(sessionDir("corrupt-001", projectRoot))).toBe(false);
+      // Its unreadable-meta diagnostic was surfaced (not swallowed).
+      expect(
+        msgs.some(
+          (m) =>
+            m.includes("corrupt-001") && m.includes("unreadable meta.json"),
+        ),
+      ).toBe(true);
+    });
+
+    it("routes a prune-failure diagnostic (not a throw) when removeSessionDir cannot delete a session", async () => {
+      // Breach the count cap, then make rmdir reject for the oldest session so
+      // its removal fails. The capture must still succeed — a janitorial
+      // failure never downgrades a snapshot-capture success.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        await seedSession(
+          projectRoot,
+          `s-${String(i).padStart(3, "0")}`,
+          `2026-03-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(
+            i,
+          ).padStart(3, "0")}Z`,
+        );
+      }
+      const oldestDir = sessionDir("s-000", projectRoot);
+      mockRmdir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(oldestDir)) {
+          return Promise.reject(mkErrno("EACCES", "rmdir denied"));
+        }
+        return realFs.rmdir(p, ...rest);
+      });
+      // unlink would empty the dir before rmdir; let it proceed normally so the
+      // failure is isolated to the rmdir call the prune relies on.
+      const fileA = join(projectRoot, "y.txt");
+      await realFs.writeFile(fileA, "y");
+      const msgs: string[] = [];
+      const result = await createSnapshot("prune-fail", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+
+      expect(result.count).toBe(1);
+      expect(
+        msgs.some(
+          (m) => m.includes("Failed to prune snapshot session s-000") && m.includes("rmdir denied"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // ── pruneSnapshots: byte cap (D6-SA6.4-F5) ───────────────────────────
+  describe("retention prune — byte cap", () => {
+    it("evicts the oldest session for the size ceiling and routes a size-cap prune message", async () => {
+      // Two seeded sessions, well under the count cap. A stat mock reports each
+      // captured/seeded file as 60 MB so the aggregate (>120 MB) breaches
+      // MAX_SNAPSHOT_BYTES (100 MB) while count stays at 3 (< 50). The oldest
+      // seeded session is evicted; the byte-cap reason wins because count is OK.
+      await seedSession(projectRoot, "big-old", "2026-04-01T00:00:00.000Z", {
+        relativePaths: ["old.txt"],
+      });
+      await realFs.writeFile(
+        join(sessionDir("big-old", projectRoot), SNAPSHOT_FILES_DIR, "old.txt"),
+        "old-bytes",
+      );
+      await seedSession(projectRoot, "big-mid", "2026-04-02T00:00:00.000Z", {
+        relativePaths: ["mid.txt"],
+      });
+      await realFs.writeFile(
+        join(sessionDir("big-mid", projectRoot), SNAPSHOT_FILES_DIR, "mid.txt"),
+        "mid-bytes",
+      );
+
+      // Report every regular file as 60 MB so the byte ceiling is breached.
+      mockStat.mockImplementation(async (p, ...rest) => {
+        const real = await realFs.stat(p, ...(rest as []));
+        if (real.isFile()) {
+          (real as unknown as { size: number }).size = 60_000_000;
+        }
+        return real;
+      });
+
+      const fileA = join(projectRoot, "z.txt");
+      await realFs.writeFile(fileA, "z");
+      const msgs: string[] = [];
+      const result = await createSnapshot("byte-cap", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+
+      expect(result.count).toBe(1);
+      // The oldest seeded session was evicted under the byte ceiling.
+      expect(await exists(sessionDir("big-old", projectRoot))).toBe(false);
+      const sizeCap = msgs.filter((m) => m.includes("size cap") && m.includes("bytes"));
+      expect(sizeCap.length).toBeGreaterThanOrEqual(1);
+      expect(sizeCap[0]).toContain("Pruned old snapshot session big-old");
+    });
+
+    it("never prunes the single most-recent session even when it alone exceeds the byte ceiling", async () => {
+      // Only the just-captured session exists. dirSizeBytes (via the stat mock)
+      // reports it as 200 MB — over the cap — but the prune loop's
+      // `aged.length - 1` upper bound protects the last (only) session.
+      mockStat.mockImplementation(async (p, ...rest) => {
+        const real = await realFs.stat(p, ...(rest as []));
+        if (real.isFile()) {
+          (real as unknown as { size: number }).size = 200_000_000;
+        }
+        return real;
+      });
+      const fileA = join(projectRoot, "lonely.txt");
+      await realFs.writeFile(fileA, "lonely");
+      const msgs: string[] = [];
+      const result = await createSnapshot("lonely-cap", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+      expect(result.count).toBe(1);
+      // The just-captured (and only) session survives.
+      expect(await exists(result.snapshotPath)).toBe(true);
+      expect(msgs.filter((m) => m.includes("Pruned old snapshot session"))).toEqual([]);
+    });
+  });
+
+  // ── dirSizeBytes / removeSessionDir recursion + vanish skip ──────────
+  describe("recursive helpers (dirSizeBytes / removeSessionDir)", () => {
+    it("sums nested files and tolerates a file vanishing mid-walk during size accounting", async () => {
+      // Breach the count cap with sessions that contain NESTED files so
+      // dirSizeBytes recurses into a subdirectory. For the oldest session, make
+      // stat reject ENOENT for the nested file (vanished mid-walk) — the sweep
+      // must skip it (not abort) and still prune the session.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `nest-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2026-05-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        const nestedDir = join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "sub");
+        await realFs.mkdir(nestedDir, { recursive: true });
+        await realFs.writeFile(join(nestedDir, "deep.txt"), "deep");
+      }
+      const vanishingFile = join(
+        sessionDir("nest-000", projectRoot),
+        SNAPSHOT_FILES_DIR,
+        "sub",
+        "deep.txt",
+      );
+      mockStat.mockImplementation((p, ...rest) => {
+        if (p === vanishingFile) return Promise.reject(mkErrno("ENOENT"));
+        return realFs.stat(p, ...rest);
+      });
+
+      const fileA = join(projectRoot, "trigger.txt");
+      await realFs.writeFile(fileA, "trigger");
+      const result = await createSnapshot("nest-trigger", [fileA], { projectRoot });
+
+      expect(result.count).toBe(1);
+      // The oldest nested session was fully removed despite the mid-walk vanish.
+      expect(await exists(sessionDir("nest-000", projectRoot))).toBe(false);
+    });
+
+    it("rethrows a non-ENOENT stat error encountered while sizing a session", async () => {
+      // A hard stat failure (EACCES) during dirSizeBytes is not benign — it must
+      // propagate out of createSnapshot rather than be swallowed as a 0-byte dir.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `acc-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2026-06-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        await realFs.writeFile(
+          join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "f.txt"),
+          "f",
+        );
+      }
+      const blockedFile = join(
+        sessionDir("acc-000", projectRoot),
+        SNAPSHOT_FILES_DIR,
+        "f.txt",
+      );
+      mockStat.mockImplementation((p, ...rest) => {
+        if (p === blockedFile) return Promise.reject(mkErrno("EACCES", "stat blocked"));
+        return realFs.stat(p, ...rest);
+      });
+      const fileA = join(projectRoot, "boom.txt");
+      await realFs.writeFile(fileA, "boom");
+      await expect(
+        createSnapshot("boom-capture", [fileA], { projectRoot }),
+      ).rejects.toThrow("stat blocked");
+    });
+
+    it("tolerates an ENOENT unlink (file vanished mid-remove) while pruning a session", async () => {
+      // Breach the count cap, then make unlink of the oldest session's files
+      // reject ENOENT (a concurrent cleanup removed them first). removeSessionDir
+      // must swallow ENOENT and still rmdir the now-empty session — the capture
+      // succeeds and the session is gone.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `unl-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2025-08-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        await realFs.writeFile(
+          join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "f.txt"),
+          "f",
+        );
+      }
+      const oldestDir = sessionDir("unl-000", projectRoot);
+      mockUnlink.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(oldestDir)) {
+          // Remove for real, THEN report ENOENT so the post-real-delete rmdir of
+          // the (now-empty) dir still succeeds and the catch's ENOENT arm runs.
+          return realFs
+            .unlink(p, ...rest)
+            .then(() => Promise.reject(mkErrno("ENOENT")));
+        }
+        return realFs.unlink(p, ...rest);
+      });
+      const fileA = join(projectRoot, "u.txt");
+      await realFs.writeFile(fileA, "u");
+      const result = await createSnapshot("unl-trigger", [fileA], { projectRoot });
+      expect(result.count).toBe(1);
+      expect(await exists(oldestDir)).toBe(false);
+    });
+
+    it("routes a prune-failure diagnostic when a session-file unlink fails with a non-ENOENT error", async () => {
+      // A non-ENOENT unlink failure inside removeSessionDir is NOT benign: it
+      // rethrows out of removeSessionDir, the prune() try/catch converts it to a
+      // routed diagnostic, and the capture still succeeds.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `unf-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2025-09-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        await realFs.writeFile(
+          join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "f.txt"),
+          "f",
+        );
+      }
+      const oldestDir = sessionDir("unf-000", projectRoot);
+      mockUnlink.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(oldestDir)) {
+          return Promise.reject(mkErrno("EPERM", "unlink locked"));
+        }
+        return realFs.unlink(p, ...rest);
+      });
+      const fileA = join(projectRoot, "uf.txt");
+      await realFs.writeFile(fileA, "uf");
+      const msgs: string[] = [];
+      const result = await createSnapshot("unf-trigger", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+      expect(result.count).toBe(1);
+      expect(
+        msgs.some(
+          (m) =>
+            m.includes("Failed to prune snapshot session unf-000") && m.includes("unlink locked"),
+        ),
+      ).toBe(true);
+    });
+
+    it("tolerates an ENOENT readdir (session vanished after enumeration) without aborting the sweep", async () => {
+      // listSessionDirs enumerates the sessions at the root, then a concurrent
+      // cleanup removes the oldest session dir before dirSizeBytes /
+      // removeSessionDir walk into it. Both helpers' readdir-ENOENT arms must
+      // treat it as 0 bytes / a no-op removal rather than throwing, so the
+      // capture still lands and no prune-failure diagnostic is emitted for it.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        await seedSession(
+          projectRoot,
+          `rd-${String(i).padStart(3, "0")}`,
+          `2025-10-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+      }
+      const oldestDir = sessionDir("rd-000", projectRoot);
+      // The ROOT readdir (listSessionDirs) still enumerates rd-000, but every
+      // readdir of the rd-000 session dir (and below) reports ENOENT — the
+      // dir vanished between enumeration and the walk. This drives the
+      // readdir-ENOENT arm in dirSizeBytes AND removeSessionDir.
+      mockReaddir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(oldestDir)) {
+          return Promise.reject(mkErrno("ENOENT")) as ReturnType<typeof realFs.readdir>;
+        }
+        return realFs.readdir(p, ...rest);
+      });
+      const fileA = join(projectRoot, "rd.txt");
+      await realFs.writeFile(fileA, "rd");
+      const msgs: string[] = [];
+      const result = await createSnapshot("rd-trigger", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+      // Capture succeeded; the vanished session did not abort the sweep.
+      expect(result.count).toBe(1);
+      // No prune-FAILURE diagnostic for rd-000 (the ENOENT was benign, not an error).
+      expect(msgs.some((m) => m.includes("Failed to prune snapshot session rd-000"))).toBe(false);
+    });
+
+    it("rethrows a non-ENOENT readdir error while sizing a session subdir", async () => {
+      // A hard (non-ENOENT) readdir failure inside dirSizeBytes is NOT benign:
+      // it must propagate out of the capture rather than be treated as a 0-byte
+      // dir. Reject readdir of the oldest session's files/ subdir with EACCES.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `szx-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2025-11-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        await realFs.writeFile(
+          join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "f.txt"),
+          "f",
+        );
+      }
+      const oldestFilesDir = join(sessionDir("szx-000", projectRoot), SNAPSHOT_FILES_DIR);
+      mockReaddir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p === oldestFilesDir) {
+          return Promise.reject(mkErrno("EACCES", "readdir size denied")) as ReturnType<
+            typeof realFs.readdir
+          >;
+        }
+        return realFs.readdir(p, ...rest);
+      });
+      const fileA = join(projectRoot, "szx.txt");
+      await realFs.writeFile(fileA, "szx");
+      await expect(
+        createSnapshot("szx-trigger", [fileA], { projectRoot }),
+      ).rejects.toThrow("readdir size denied");
+    });
+
+    it("routes a prune-failure diagnostic when removeSessionDir's readdir fails with a non-ENOENT error", async () => {
+      // removeSessionDir's readdir throwing a non-ENOENT error rethrows out of
+      // removeSessionDir; prune()'s try/catch converts it to a routed failure
+      // diagnostic and the capture still succeeds. dirSizeBytes is left intact
+      // (stat-based on the files), so only the removal readdir is faulted.
+      for (let i = 0; i < MAX_SNAPSHOT_COUNT; i++) {
+        const sid = `rmx-${String(i).padStart(3, "0")}`;
+        await seedSession(
+          projectRoot,
+          sid,
+          `2025-12-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.${String(i).padStart(3, "0")}Z`,
+        );
+        await realFs.writeFile(
+          join(sessionDir(sid, projectRoot), SNAPSHOT_FILES_DIR, "f.txt"),
+          "f",
+        );
+      }
+      const oldestDir = sessionDir("rmx-000", projectRoot);
+      const oldestFilesDir = join(oldestDir, SNAPSHOT_FILES_DIR);
+      // dirSizeBytes also calls readdir(oldestDir)/readdir(oldestFilesDir); to
+      // isolate the FAILURE to removeSessionDir we reject ONLY after the first
+      // (sizing) pass. dirSizeBytes(oldestDir) reads oldestDir then oldestFilesDir;
+      // removeSessionDir(oldestDir) reads them again. Fault the 3rd+ readdir of
+      // the oldest dir (the removal pass) with EACCES.
+      let oldestDirReads = 0;
+      mockReaddir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && (p === oldestDir || p === oldestFilesDir)) {
+          oldestDirReads += 1;
+          // First two reads (dirSizeBytes: dir + files/) succeed; the removal
+          // pass (read #3 onward) fails non-ENOENT.
+          if (oldestDirReads > 2) {
+            return Promise.reject(mkErrno("EACCES", "readdir rm denied")) as ReturnType<
+              typeof realFs.readdir
+            >;
+          }
+        }
+        return realFs.readdir(p, ...rest);
+      });
+      const fileA = join(projectRoot, "rmx.txt");
+      await realFs.writeFile(fileA, "rmx");
+      const msgs: string[] = [];
+      const result = await createSnapshot("rmx-trigger", [fileA], {
+        projectRoot,
+        onWarn: (m) => msgs.push(m),
+      });
+      expect(result.count).toBe(1);
+      expect(
+        msgs.some(
+          (m) => m.includes("Failed to prune snapshot session rmx-000") && m.includes("readdir rm denied"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  // ── listSnapshots / listSessionDirs root readdir failure ─────────────
+  describe("listSessionDirs root readdir failure", () => {
+    it("propagates a non-ENOENT readdir error on the snapshot root out of listSnapshots", async () => {
+      // listSessionDirs returns [] on ENOENT (first-run), but a hard readdir
+      // failure of the root (EACCES) is not first-run — it must propagate so the
+      // caller sees the real I/O fault instead of an empty list.
+      const root = snapshotsRoot(projectRoot);
+      await realFs.mkdir(root, { recursive: true });
+      mockReaddir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p === root) {
+          return Promise.reject(mkErrno("EACCES", "root readdir denied")) as ReturnType<
+            typeof realFs.readdir
+          >;
+        }
+        return realFs.readdir(p, ...rest);
+      });
+      await expect(listSnapshots({ projectRoot })).rejects.toThrow("root readdir denied");
+    });
+  });
+
+  // ── mirrorRelativePath defensive ".." traversal guard ────────────────
+  describe("mirrorRelativePath traversal guard", () => {
+    it("throws a VALIDATION_ERROR HatchError when relative() yields an interior '..' segment", async () => {
+      // `relative()` collapses traversal on a real fs, so the defensive in-tree
+      // ".." check is unreachable without forcing the function to return a path
+      // that does NOT start with ".." yet contains an interior ".." segment.
+      const fileA = join(projectRoot, "trap.txt");
+      await realFs.writeFile(fileA, "trap");
+      mockRelative.mockImplementation((from, to) => {
+        // A literal interior ".." segment that does NOT start with ".." and is
+        // not absolute — the exact shape the in-tree defensive guard catches.
+        // Built with the real path.sep so it splits into a "../" segment.
+        if (to === fileA) return ["inside", "..", "escape.txt"].join(realPath.sep);
+        return realPath.relative(from, to);
+      });
+      const err = await createSnapshot("traversal", [fileA], { projectRoot }).then(
+        () => {
+          throw new Error("expected createSnapshot to reject with a traversal HatchError");
+        },
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/refusing to snapshot path with traversal/);
+      expect((err as { errorCode?: string }).errorCode).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  // ── withSnapshot environmental downgrade vs programming-bug propagate ─
+  describe("withSnapshot snapshot-capture failure handling", () => {
+    it("downgrades an environmental capture failure to a warning, still runs the mutator, and returns null sessionId", async () => {
+      // Force createSnapshot's first disk write to fail with a non-validation
+      // (environmental) error. Per the doc contract this downgrades to a
+      // warning, the mutator still runs, and the returned sessionId is null so
+      // the caller suppresses its "revert with: …" line.
+      const fileA = join(projectRoot, "wire-env.txt");
+      await realFs.writeFile(fileA, "env-original");
+      // mkdir(filesDir) is the first write createSnapshot performs; reject it
+      // with an environmental (non-VALIDATION) errno.
+      const filesPrefix = snapshotsRoot(projectRoot);
+      mockMkdir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(filesPrefix)) {
+          return Promise.reject(mkErrno("EACCES", "snapshot dir not writable"));
+        }
+        return realFs.mkdir(p, ...rest);
+      });
+
+      let mutatorRan = false;
+      const warns: string[] = [];
+      const out = await withSnapshot(
+        "sync",
+        [fileA],
+        async (sessionId) => {
+          mutatorRan = true;
+          expect(sessionId).toBeNull();
+          return "mutated" as const;
+        },
+        {
+          projectRoot,
+          now: () => new Date("2026-07-01T00:00:00.000Z"),
+          onWarn: (m) => warns.push(m),
+        },
+      );
+
+      expect(mutatorRan).toBe(true);
+      expect(out.result).toBe("mutated");
+      expect(out.sessionId).toBeNull();
+      expect(out.snapshotPath).toBeNull();
+      expect(out.count).toBe(0);
+      expect(
+        warns.some(
+          (m) => m.includes("Pre-mutation snapshot failed") && m.includes("snapshot dir not writable"),
+        ),
+      ).toBe(true);
+    });
+
+    it("routes the environmental-failure warning through console.warn when no onWarn is supplied", async () => {
+      const fileA = join(projectRoot, "wire-env2.txt");
+      await realFs.writeFile(fileA, "env2");
+      const filesPrefix = snapshotsRoot(projectRoot);
+      mockMkdir.mockImplementation((p, ...rest) => {
+        if (typeof p === "string" && p.startsWith(filesPrefix)) {
+          return Promise.reject(mkErrno("EROFS", "read-only fs"));
+        }
+        return realFs.mkdir(p, ...rest);
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const out = await withSnapshot(
+        "init",
+        [fileA],
+        async () => "ok" as const,
+        { projectRoot, now: () => new Date("2026-07-02T00:00:00.000Z") },
+      );
+
+      expect(out.result).toBe("ok");
+      expect(out.sessionId).toBeNull();
+      expect(
+        warnSpy.mock.calls.some((c) => String(c[0]).includes("Pre-mutation snapshot failed")),
+      ).toBe(true);
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ── listSnapshots DEBUG diagnostic ───────────────────────────────────
+  describe("listSnapshots DEBUG diagnostic", () => {
+    it("logs an unreadable-meta diagnostic to console.error when DEBUG is set", async () => {
+      const dir = sessionDir("dbg-broken", projectRoot);
+      await realFs.mkdir(dir, { recursive: true });
+      await realFs.writeFile(join(dir, SNAPSHOT_META_FILE), "{still not json");
+      const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      process.env.DEBUG = "1";
+
+      const out = await listSnapshots({ projectRoot });
+
+      expect(out).toEqual([]);
+      expect(
+        errSpy.mock.calls.some(
+          (c) => String(c[0]).includes("dbg-broken") && String(c[0]).includes("meta unreadable"),
+        ),
+      ).toBe(true);
+      errSpy.mockRestore();
+    });
+  });
+
+  // ── applyRollback prepare-phase branches ─────────────────────────────
+  describe("applyRollback prepare-phase error branches", () => {
+    it("records a stat error (non-ENOENT) on the tombstone probe as a prepare failure and aborts", async () => {
+      const futurePath = join(projectRoot, "ghost.txt");
+      const snap = await createSnapshot("rb-stat", [futurePath], { projectRoot });
+      const tombstone = join(
+        snap.snapshotPath,
+        SNAPSHOT_FILES_DIR,
+        "ghost.txt.tombstone",
+      );
+      // stat(tombstone) rejects with EACCES (not ENOENT) → prepare records the
+      // error and the live rollback aborts with everything mutated-still.
+      mockStat.mockImplementation((p, ...rest) => {
+        if (p === tombstone) return Promise.reject(mkErrno("EACCES", "tombstone stat denied"));
+        return realFs.stat(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-stat", { projectRoot });
+      expect(result.filesRestored).toBe(0);
+      expect(result.errors.some((e) => /aborted/.test(e))).toBe(true);
+      expect(result.errors.some((e) => /tombstone stat denied/.test(e))).toBe(true);
+      expect((result.dispositions ?? []).every((d) => d.state === "mutated-still")).toBe(true);
+    });
+
+    it("records a tombstone parent-not-writable EACCES as a prepare failure", async () => {
+      const futurePath = join(projectRoot, "victim.txt");
+      await createSnapshot("rb-tomb-eacces", [futurePath], { projectRoot });
+      // access(dirname(target), W_OK) rejects with EACCES (not ENOENT) for the
+      // tombstone's parent → entry.error set, live rollback aborts.
+      mockAccess.mockImplementation((p, ...rest) => {
+        if (p === projectRoot) return Promise.reject(mkErrno("EACCES", "parent ro"));
+        return realFs.access(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-tomb-eacces", { projectRoot });
+      expect(result.filesRestored).toBe(0);
+      expect(result.errors.some((e) => /parent not writable/.test(e))).toBe(true);
+      expect(result.errors.some((e) => /parent ro/.test(e))).toBe(true);
+    });
+
+    it("treats a tombstone parent ENOENT as benign (missing parent = target already absent)", async () => {
+      const futurePath = join(projectRoot, "missing-parent", "child.txt");
+      await createSnapshot("rb-tomb-enoent", [futurePath], { projectRoot });
+      // access(dirname(target)) rejects ENOENT → benign, entry has no error, the
+      // tombstone restore is a clean no-op (target already absent).
+      const parent = join(projectRoot, "missing-parent");
+      mockAccess.mockImplementation((p, ...rest) => {
+        if (p === parent) return Promise.reject(mkErrno("ENOENT"));
+        return realFs.access(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-tomb-enoent", { projectRoot });
+      expect(result.errors).toEqual([]);
+      expect(result.filesRestored).toBe(1);
+      expect(result.dispositions?.[0].state).toBe("original-restored");
+    });
+
+    it("records a regular-entry destination-not-writable EACCES as a prepare failure", async () => {
+      const fileA = join(projectRoot, "reg.txt");
+      await realFs.writeFile(fileA, "orig");
+      await createSnapshot("rb-dest-eacces", [fileA], { projectRoot });
+      await realFs.writeFile(fileA, "mut");
+      // The regular entry's mkdir+access(dirname, W_OK) rejects with EACCES.
+      mockAccess.mockImplementation((p, ...rest) => {
+        if (p === projectRoot) return Promise.reject(mkErrno("EACCES", "dest ro"));
+        return realFs.access(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-dest-eacces", { projectRoot });
+      expect(result.filesRestored).toBe(0);
+      expect(result.errors.some((e) => /destination not writable/.test(e))).toBe(true);
+      expect(result.errors.some((e) => /dest ro/.test(e))).toBe(true);
+      // Disk untouched — still holds the mutation.
+      expect(await realFs.readFile(fileA, "utf-8")).toBe("mut");
+    });
+
+    it("surfaces a prepare-phase stat error in dry-run mode as a mutated-still disposition", async () => {
+      const futurePath = join(projectRoot, "dry-ghost.txt");
+      const snap = await createSnapshot("rb-dry-stat", [futurePath], { projectRoot });
+      const tombstone = join(
+        snap.snapshotPath,
+        SNAPSHOT_FILES_DIR,
+        "dry-ghost.txt.tombstone",
+      );
+      mockStat.mockImplementation((p, ...rest) => {
+        if (p === tombstone) return Promise.reject(mkErrno("EIO", "io error"));
+        return realFs.stat(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-dry-stat", { dryRun: true, projectRoot });
+      // Dry-run reports zero clean restores and surfaces the prepare error.
+      expect(result.filesRestored).toBe(0);
+      expect(result.errors.some((e) => /io error/.test(e))).toBe(true);
+      expect(result.dispositions?.[0].state).toBe("mutated-still");
+      expect(result.dispositions?.[0].error).toMatch(/io error/);
+    });
+  });
+
+  // ── applyRollback commit-phase failure + roll-forward ────────────────
+  describe("applyRollback commit-phase failure and roll-forward (all-or-nothing)", () => {
+    it("rolls a successfully-applied entry FORWARD to its pre-rollback bytes when a later commit write fails", async () => {
+      // Two regular entries. Both prepare cleanly (mirror readable, parent
+      // writable). At commit time entry B's atomicWriteFile fails — we make B's
+      // target a non-empty directory so the tmp→target rename throws. That trips
+      // commitFailedAt, and the already-restored entry A is rolled forward to
+      // its pre-rollback (mutated) bytes — net all-or-nothing.
+      const fileA = join(projectRoot, "roll-a.txt");
+      const fileB = join(projectRoot, "roll-b.txt");
+      await realFs.writeFile(fileA, "orig A");
+      await realFs.writeFile(fileB, "orig B");
+      await createSnapshot("rb-rollfwd", [fileA, fileB], { projectRoot });
+      // Mutate A, then replace B's file with a non-empty directory.
+      await realFs.writeFile(fileA, "mut A");
+      await realFs.rm(fileB);
+      await realFs.mkdir(fileB, { recursive: true });
+      await realFs.writeFile(join(fileB, "blocker.txt"), "blocks rename");
+
+      const result = await applyRollback("rb-rollfwd", { projectRoot });
+
+      // Net: the rollback failed all-or-nothing — at least one error, and A was
+      // rolled forward (not left restored).
+      expect(result.errors.length).toBeGreaterThan(0);
+      const dispA = (result.dispositions ?? []).find((d) => d.target === fileA);
+      const dispB = (result.dispositions ?? []).find((d) => d.target === fileB);
+      expect(dispA?.state).toBe("rolled-forward");
+      expect(dispB?.state).toBe("mutated-still");
+      // filesRestored decremented back: A was restored then rolled forward.
+      expect(result.filesRestored).toBe(0);
+      // A is back to its pre-rollback (mutated) bytes on disk.
+      expect(await realFs.readFile(fileA, "utf-8")).toBe("mut A");
+    });
+
+    it("re-deletes an entry that was absent pre-rollback when rolling forward after a commit failure", async () => {
+      // Entry A is a TOMBSTONE for a path that did NOT exist pre-run; at rollback
+      // time A exists (created during the run) so the tombstone restore deletes
+      // it. Entry B then fails at commit. Roll-forward of A must RE-CREATE it to
+      // its pre-rollback bytes (snap.bytes !== null path is the file-present
+      // case; here we cover the snap.bytes === null re-delete branch by making A
+      // a regular restore of a file that was absent pre-rollback).
+      //
+      // Concretely: A is a regular entry whose target is ABSENT at rollback time
+      // (mutatedSnaps records bytes:null). Restoring A creates the file; the
+      // later B failure rolls A forward by re-deleting it (snap.bytes === null).
+      const fileA = join(projectRoot, "recreate-a.txt");
+      const fileB = join(projectRoot, "recreate-b.txt");
+      await realFs.writeFile(fileA, "orig A");
+      await realFs.writeFile(fileB, "orig B");
+      await createSnapshot("rb-redelete", [fileA, fileB], { projectRoot });
+      // A is removed before rollback → at commit, pre-rollback bytes of A are
+      // null, so roll-forward re-deletes the file the restore created.
+      await realFs.rm(fileA);
+      // B becomes a non-empty dir so its commit write fails.
+      await realFs.rm(fileB);
+      await realFs.mkdir(fileB, { recursive: true });
+      await realFs.writeFile(join(fileB, "blocker.txt"), "blocks");
+
+      const result = await applyRollback("rb-redelete", { projectRoot });
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      const dispA = (result.dispositions ?? []).find((d) => d.target === fileA);
+      expect(dispA?.state).toBe("rolled-forward");
+      // A was re-deleted (absent pre-rollback) → still absent after roll-forward.
+      expect(await exists(fileA)).toBe(false);
+    });
+
+    it("marks an applied entry UNKNOWN when its pre-rollback bytes were unreadable", async () => {
+      // Two entries. A restores fine. We make the pre-rollback read of A's target
+      // fail with a non-ENOENT error so mutatedSnaps records {unreadable:true}.
+      // Then B fails at commit → roll-forward of A cannot proceed → disposition
+      // UNKNOWN with the "cannot roll forward" message.
+      const fileA = join(projectRoot, "unk-a.txt");
+      const fileB = join(projectRoot, "unk-b.txt");
+      await realFs.writeFile(fileA, "orig A");
+      await realFs.writeFile(fileB, "orig B");
+      await createSnapshot("rb-unknown", [fileA, fileB], { projectRoot });
+      await realFs.writeFile(fileA, "mut A");
+      // B → non-empty dir so its commit write fails.
+      await realFs.rm(fileB);
+      await realFs.mkdir(fileB, { recursive: true });
+      await realFs.writeFile(join(fileB, "blocker.txt"), "blocks");
+
+      // The ONLY readFile of fileA target happens in the commit pre-snapshot
+      // loop (prepare reads the snapshot mirror, not the target). Reject that
+      // one with EACCES so the pre-rollback bytes are unreadable.
+      mockReadFile.mockImplementation((p, ...rest) => {
+        if (p === fileA) return Promise.reject(mkErrno("EACCES", "target unreadable"));
+        return realFs.readFile(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-unknown", { projectRoot });
+
+      const dispA = (result.dispositions ?? []).find((d) => d.target === fileA);
+      expect(dispA?.state).toBe("unknown");
+      expect(dispA?.error).toMatch(/pre-rollback bytes unreadable; cannot roll forward/);
+    });
+
+    it("records UNKNOWN with a roll-forward error when the roll-forward write itself fails", async () => {
+      // A restores fine; its pre-rollback bytes are readable (file present). B
+      // fails at commit → roll-forward of A runs atomicWriteFile back to A's
+      // mutated bytes. We make THAT write fail (rename onto a path turned into a
+      // dir between commit and roll-forward) so the disposition is UNKNOWN with a
+      // "roll-forward failed" error.
+      const fileA = join(projectRoot, "rfw-a.txt");
+      const fileB = join(projectRoot, "rfw-b.txt");
+      await realFs.writeFile(fileA, "orig A");
+      await realFs.writeFile(fileB, "orig B");
+      await createSnapshot("rb-rfw-fail", [fileA, fileB], { projectRoot });
+      await realFs.writeFile(fileA, "mut A");
+      await realFs.rm(fileB);
+      await realFs.mkdir(fileB, { recursive: true });
+      await realFs.writeFile(join(fileB, "blocker.txt"), "blocks");
+
+      // Let the commit-phase atomicWriteFile to A succeed (restore), then make
+      // the roll-forward atomicWriteFile to A fail. atomicWriteFile renames
+      // <A>.tmp.<hex> → A. Reject the rename for A after the first successful
+      // restore so only the roll-forward write fails.
+      let renameCount = 0;
+      mockRename.mockImplementation((from, to, ...rest) => {
+        if (typeof to === "string" && to === fileA) {
+          renameCount += 1;
+          // First rename (commit restore of A) succeeds; second (roll-forward) fails.
+          if (renameCount >= 2) {
+            return Promise.reject(mkErrno("EIO", "roll-forward rename failed"));
+          }
+        }
+        return realFs.rename(from, to, ...rest);
+      });
+
+      const result = await applyRollback("rb-rfw-fail", { projectRoot });
+
+      const dispA = (result.dispositions ?? []).find((d) => d.target === fileA);
+      expect(dispA?.state).toBe("unknown");
+      expect(dispA?.error).toMatch(/roll-forward failed for/);
+      expect(result.errors.some((e) => /roll-forward/.test(e))).toBe(true);
+    });
+
+    it("swallows an ENOENT during a re-delete roll-forward (target already gone) and reports rolled-forward", async () => {
+      // A was absent pre-rollback (snap.bytes === null) → restore creates it,
+      // then a B commit failure rolls A forward by re-deleting it. Make that
+      // re-delete unlink reject ENOENT (a concurrent process already removed A):
+      // the catch's ENOENT arm swallows it, and A's disposition stays
+      // rolled-forward (the all-or-nothing intent is satisfied — A is gone).
+      const fileA = join(projectRoot, "rd-a.txt");
+      const fileB = join(projectRoot, "rd-b.txt");
+      await realFs.writeFile(fileA, "orig A");
+      await realFs.writeFile(fileB, "orig B");
+      await createSnapshot("rb-redelete-enoent", [fileA, fileB], { projectRoot });
+      await realFs.rm(fileA); // absent pre-rollback → snap.bytes === null
+      await realFs.rm(fileB);
+      await realFs.mkdir(fileB, { recursive: true });
+      await realFs.writeFile(join(fileB, "blocker.txt"), "blocks");
+
+      // The ONLY direct unlink(fileA) (no .tmp suffix) is the roll-forward
+      // re-delete; reject it ENOENT. Tombstone/atomic-write tmp unlinks are
+      // unaffected (they carry the .tmp.<hex> suffix or target other paths).
+      mockUnlink.mockImplementation((p, ...rest) => {
+        if (p === fileA) return Promise.reject(mkErrno("ENOENT"));
+        return realFs.unlink(p, ...rest);
+      });
+
+      const result = await applyRollback("rb-redelete-enoent", { projectRoot });
+
+      const dispA = (result.dispositions ?? []).find((d) => d.target === fileA);
+      expect(dispA?.state).toBe("rolled-forward");
+      // No roll-forward error recorded for A — the ENOENT was benign.
+      expect(dispA?.error).toBeUndefined();
+    });
+  });
+
+  // ── createSnapshot capture-time error branches ───────────────────────
+  describe("createSnapshot directory input + capture read failure", () => {
+    it("rethrows a non-ENOENT error encountered while reading a file to capture it", async () => {
+      // A file that exists at capture time but whose readFile fails with a hard
+      // (non-ENOENT) error must propagate — it is not a "file absent" tombstone
+      // case. ENOENT → tombstone (covered elsewhere); EACCES → throw.
+      const fileA = join(projectRoot, "locked.txt");
+      await realFs.writeFile(fileA, "secret");
+      mockReadFile.mockImplementation((p, ...rest) => {
+        if (p === fileA) return Promise.reject(mkErrno("EACCES", "read denied"));
+        return realFs.readFile(p, ...rest);
+      });
+      await expect(
+        createSnapshot("cap-read-fail", [fileA], { projectRoot }),
+      ).rejects.toThrow("read denied");
+    });
+
+    it("records a tombstone (not a byte copy) when an input path is an existing directory", async () => {
+      // A path that exists and is a directory must be tombstoned, not copied
+      // byte-for-byte — so a later rollback can remove whatever file the
+      // orchestrator places at that path without descending the whole tree.
+      const subdir = join(projectRoot, "a-real-dir");
+      await realFs.mkdir(subdir, { recursive: true });
+      await realFs.writeFile(join(subdir, "inner.txt"), "inner");
+
+      const result = await createSnapshot("dir-tomb", [subdir], { projectRoot });
+      expect(result.count).toBe(1);
+      // A .tombstone sentinel was written for the directory mirror; no byte copy.
+      const tombstone = join(result.snapshotPath, SNAPSHOT_FILES_DIR, "a-real-dir.tombstone");
+      expect(await exists(tombstone)).toBe(true);
+      expect(await exists(join(result.snapshotPath, SNAPSHOT_FILES_DIR, "a-real-dir", "inner.txt"))).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/src/__tests__/workspace/sync.test.ts
+++ b/src/__tests__/workspace/sync.test.ts
@@ -624,7 +624,10 @@ describe("workspace sync", () => {
       const entry = persisted!.repos.find((r) => r.path === name);
       expect(entry?.lastSync, `lastSync for ${name}`).toBeDefined();
     }
-  });
+    // Windows runners run real multi-repo git+adapter work ~5-10x slower; 30s
+    // default is borderline — give headroom (test completes in ~6s on macOS,
+    // never hangs). 5 real `git init` repos + 5 real adapter generations.
+  }, 90_000);
 
   // D14-SA14.2-H01 (High, C9-H45): The `concurrency` option caps the
   // number of sub-repo syncs in flight simultaneously. Verified by
@@ -695,7 +698,12 @@ describe("workspace sync", () => {
     } finally {
       getAdapterSpy.mockRestore();
     }
-  });
+    // Windows runners run real multi-repo git+adapter work ~5-10x slower; 30s
+    // default is borderline — give headroom (test completes in ~7.6s on macOS,
+    // never hangs). 5 real `git init` repos + 5 real adapter generations, each
+    // with a forced 25ms overlap delay to make the concurrency-cap assertion
+    // observable; the cap logic itself is exercised real, not mocked.
+  }, 90_000);
 
   // D14-SA14.2-H01 (High, C9-H45): The sync journal at
   // `<workspaceRoot>/.agents/.workspace-sync-journal.jsonl` records one

--- a/src/__tests__/workspace/sync.test.ts
+++ b/src/__tests__/workspace/sync.test.ts
@@ -23,7 +23,12 @@ describe("workspace detect", () => {
   let tempDir: string;
 
   afterEach(async () => {
-    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    // Windows-safe teardown: fs.rm retries ENOTEMPTY/EBUSY/EPERM with a linear
+    // backoff when recursive:true (Node fs docs, accessed 2026-06-04:
+    // https://nodejs.org/api/fs.html). These tests create real git repos whose
+    // file handles Windows may still hold; the retries cover the brief
+    // deferred-deletion window. Inert on POSIX (first attempt succeeds).
+    if (tempDir) await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   async function setup(): Promise<string> {
@@ -166,7 +171,9 @@ describe("isWorkspaceRoot", () => {
   let tempDir: string;
 
   afterEach(async () => {
-    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    // Windows-safe teardown — see the rationale on the "workspace detect"
+    // afterEach above: fs.rm retries ENOTEMPTY/EBUSY/EPERM (recursive:true).
+    if (tempDir) await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it("returns true for directory with workspace.json", async () => {
@@ -211,7 +218,12 @@ describe("workspace sync", () => {
   let tempDir: string;
 
   afterEach(async () => {
-    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+    // Windows-safe teardown — see the rationale on the "workspace detect"
+    // afterEach above. This block's parallel/concurrency-cap tests create 5
+    // git repos and run 5 real adapter generations, so they hold the most
+    // file handles and are the most prone to the deferred-deletion ENOTEMPTY
+    // that caused the CI failure; the retries cover that window.
+    if (tempDir) await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   async function createGitRepo(dir: string): Promise<void> {

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1536,7 +1536,14 @@ async function validateContentBody(
       }
       // Compute the relative label for the finding message — relative to the
       // canonical content root so the label reads e.g. `rules/foo.md`.
-      const fileLabel = filePath.slice(canonicalRoot.length + 1);
+      // Windows: `filePath` carries native `\` separators (join in
+      // listMarkdownFiles), but this label is both shown to users as a POSIX
+      // path AND matched against POSIX `/` prefixes/suffixes in
+      // requiresAmbiguityGate (e.g. `agents/shared/`, `/SKILL.md`). Without
+      // normalization the `agents/shared/` + `agents/modes/` companion-file
+      // exemption misses on Windows, raising a spurious "missing §0 ambiguity
+      // gate" error that fails every validate run. Force forward slashes.
+      const fileLabel = filePath.slice(canonicalRoot.length + 1).split(/[\\/]/).join(posix.sep);
 
       // Split frontmatter vs body. The body is the only scan target — banned
       // phrases inside frontmatter `description:` are caught by the

--- a/src/cliTools/registry.ts
+++ b/src/cliTools/registry.ts
@@ -182,6 +182,8 @@ export const AVAILABLE_CLI_TOOLS = {
     // amber-flag noise for the long gap; the tool is the canonical search
     // primitive across hatch3r-cli-* skills and not at risk of abandonment.
     releaseCadence: "stable",
+    // CVE-2021-3013 (GHSA-g4xg-fxmg-vcg5) OS command injection — fixed in ripgrep 13.0.0
+    minVersion: ">=13.0.0",
     homepage: "https://github.com/BurntSushi/ripgrep",
   },
   fd: {
@@ -270,6 +272,8 @@ export const AVAILABLE_CLI_TOOLS = {
       linux: [{ manager: "apt", command: "sudo apt install git-delta" }],
       win: [{ manager: "scoop", command: "scoop install delta" }],
     },
+    // CVE-2021-36376 (GHSA-5xg3-j2j6-rcx4) path traversal — fixed in git-delta 0.8.3
+    minVersion: ">=0.8.3",
     homepage: "https://github.com/dandavison/delta",
   },
   bat: {
@@ -291,6 +295,8 @@ export const AVAILABLE_CLI_TOOLS = {
     // as abandonment; bat is the canonical syntax-aware view tool in
     // hatch3r-cli-toolbox and remains under active maintenance.
     releaseCadence: "stable",
+    // CVE-2021-36753 (GHSA-p24j-h477-76q3) uncontrolled search path — fixed in bat 0.18.2
+    minVersion: ">=0.18.2",
     homepage: "https://github.com/sharkdp/bat",
   },
   sd: {
@@ -397,6 +403,8 @@ export const AVAILABLE_CLI_TOOLS = {
     // a certificate-loading fix — but cadence has slowed. Tag stable so the
     // staleness heuristic does not auto-flag the long gap as abandonment.
     releaseCadence: "stable",
+    // CVE-2023-48052 (GHSA-8r96-8889-qg2x) + CVE-2019-10751 (GHSA-xjjg-vmw6-c2p9) — both fixed by httpie 3.2.3
+    minVersion: ">=3.2.3",
     homepage: "https://httpie.io/",
   },
   xh: {

--- a/src/migration/agentsToHatch3r.ts
+++ b/src/migration/agentsToHatch3r.ts
@@ -1,6 +1,22 @@
 import { access, mkdir, readFile, readdir, rename, rmdir, stat } from "node:fs/promises";
-import { dirname, join, relative } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { HATCH3R_DIR, MANIFEST_FILE } from "../types.js";
+
+/**
+ * Repo-relative path rendered with forward slashes regardless of host OS.
+ *
+ * `relative()` yields backslashes on Windows; the rest of this module's
+ * operator-facing display strings (the `moved` entries below) are
+ * hardcoded forward-slash, and the consolidated `console.warn` conflict
+ * summary must read identically on every platform. These paths are display
+ * /diagnostic only — never persisted to a cross-platform artifact nor parsed
+ * back — so normalizing the separator is safe and removes the sole
+ * Windows-vs-POSIX divergence in the conflict report.
+ */
+function toDisplayPath(rootDir: string, absPath: string): string {
+  const rel = relative(rootDir, absPath);
+  return sep === "/" ? rel : rel.split(sep).join("/");
+}
 
 /**
  * Legacy `.agents/` directory name retained ONLY in this migration shim.
@@ -239,8 +255,8 @@ function recordIfConflict(
     outcome.identical === false
   ) {
     conflicts.push({
-      sourcePath: relative(rootDir, sourcePath),
-      destPath: relative(rootDir, destPath),
+      sourcePath: toDisplayPath(rootDir, sourcePath),
+      destPath: toDisplayPath(rootDir, destPath),
       kind,
       reason: outcome.detail,
     });


### PR DESCRIPTION
## What

Makes CI **green and clean on the post-privatization `main` across all 9 OS×Node combinations** (ubuntu / macos / windows × node 22/24/26) — CI ran against this branch for the first time after the governance privatization and surfaced failures on every gate. Almost entirely test/CI fixes; the two product changes are Windows cross-platform bugfixes (no behavior change on POSIX).

## Commit groups

**Test gating** (`ba8d88f`) — Cluster A: `validate-rule-pillar-currency` + `userContent` D20 tests read private `governance/` files absent in public CI → gated on `existsSync`. Cluster B: init tests used the real `findMissingCliTools()`; a clean-runner missing tool fired an extra `offerInstaller` prompt that desynced the inquirer mock queue → mock `findMissingCliTools → []`.

**CVE pins + cve-check** (`1343bd2`, `6cd12f7`) — pinned `minVersion` at the CVE-fixed version for ripgrep/delta/bat/httpie; added documented `SCAN_EXEMPT_TOOLS` (rtk, comby) + `ACKNOWLEDGED_ADVISORIES` (`GHSA-g76p-4vg5-f4qh` llm, no upstream fix) mechanisms + mapped the 6 remaining tools; 18 new tests. `cli-tools:cve-check` → exit 0, `unmapped 0`. **Gate still fails on any non-acknowledged stale Critical/High.**

**Coverage** (`3731ae6`) — `src/merge/**` → 99.18/95.43/100/99.39 and `src/pipeline/snapshot.ts` → 99.35/86.41/100/100 (were below 90/80/90/90 and 90/77/90/90). Genuine real-behavior tests; adversarially reviewed (caught + fixed a false dead-code claim at `safeWrite.ts:690`).

**Lint + inventory** (`94a261a`, `2349585`, `803abe8`) — cleared 3 dead-import warnings + a stale docstring; regenerated `inventory.json`; made `lastUpdated` deterministic (`reconcileLastUpdated` preserves it unless `{counts,files}` change) so the `git diff --exit-code` drift gate stops flapping on the daily timestamp.

**Windows cross-platform** (`230ce2a`, `6b518a7`, `cf3317e`, `7df4e90`) — 15 Windows-only failures fixed:
- **Source bugs:** `validate.ts` — `fileLabel` built from a native `\` path then matched POSIX `/` prefixes in `requiresAmbiguityGate` → spurious "§0 ambiguity-gate missing" errors → `validate` **threw on Windows** (now POSIX-normalized). `agentsToHatch3r.ts` — conflict-report paths emitted `\` (now `/` via `toDisplayPath`).
- **`.gitattributes`** `* text=auto eol=lf` — forces LF on Windows checkout (zero content churn; repo blobs already LF).
- **Tests:** CRLF compare normalize, path-sep assertions, fs-mock fault injection, `process.platform` stub hardening, and Windows-safe temp-dir teardown (`fs.rm` retries for `ENOTEMPTY`).
- **CI:** raised the Windows build-job timeout to 25m (the slowest red jobs were *timeouts*, not test failures — node 26 passed the full suite green in ~10 min on the same commit) + 90s per-test timeout on the 2 heaviest 5-repo parallel-sync tests.

## Verification
- **Full CI green: all 9 OS×Node build jobs + Supply chain security pass.**
- Full suite **4489 passed / 0 failed**; coverage gate exit 0; `cli-tools:cve-check` exit 0; `inventory` no-op regen; `validate:canonical` 0 warnings; `tsc` clean; `eslint src/` 0 problems.
- Each cluster verified via adversarial review and/or platform-faithful reproduction (governance-less clone, missing-tool flip-test, future-date inventory sim, Windows CI re-runs).

## Remaining follow-ups (non-failing — flagged, not in this PR)
- **`normalizeSeverity` Go-record blind spot:** docker/podman carry real HIGH advisories OSV returns as `GO-####` records without numeric severity → filtered as UNKNOWN. No upstream fix; tracked in each tool's `securityNote` + a code comment. Teaching `normalizeSeverity` to resolve GHSA aliases would surface them — a scoped capability follow-up.
- **CI note:** `validate:canonical` reads `dist/content` when present — ensure `npm run build` precedes it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
