### PR TITLE
fix(test): windows-aware heavy-fs testTimeout to stop init-test flakiness

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -130,7 +130,14 @@ export default defineConfig({
         test: {
           name: "heavy-fs",
           include: HEAVY_FS_TEST_FILES,
-          testTimeout: 30000,
+          // Heavy-fs tests materialize full content trees (many file writes); on
+          // I/O-slow windows-latest CI runners the heaviest (full x 3-adapter
+          // init + the GitHub/Azure/GitLab interactive single-repo flows)
+          // intermittently exceed a flat 30s -> spurious "Test timed out in
+          // 30000ms" (variance: same tests pass on faster runners). Give windows
+          // headroom; keep the tight 30s hang-tripwire on the fast OSes
+          // (Linux/macOS finish well under it). Per-test overrides still win.
+          testTimeout: process.platform === "win32" ? 120000 : 30000,
           hookTimeout: 30000,
           // Later group → runs alone, after "main" fully drains.
           sequence: { groupOrder: 1 },


### PR DESCRIPTION
## Summary

Stops the recurring **windows CI flakiness** in the `heavy-fs` test lane by giving it a windows-only timeout.

## Why

The heavy-fs init tests materialize full content trees (many file writes). On I/O-slow `windows-latest` runners the heaviest ones intermittently exceed the flat **30s `testTimeout`** and fail with `Test timed out in 30000ms` — pure runner **variance** (the same tests pass on faster runners and on Linux/macOS).

- #104 patched only **D6-12**.
- PR #105's `build (24, windows-latest)` run then surfaced **three more**: the GitHub / Azure DevOps / GitLab interactive single-repo flows (`init.test.ts:1635 / :1649 / :1669`).

Whack-a-mole per test won't hold — other heavy-fs tests sit right at the boundary.

## Fix

Set the `heavy-fs` project `testTimeout` to `process.platform === "win32" ? 120000 : 30000`:
- **Windows** gets headroom for every heavy-fs test in one place.
- **Linux/macOS** keep the tight 30s hang-tripwire (they finish well under it).
- Per-test overrides (e.g. D6-12's explicit 120s) still take precedence.

## Verification

- `tsc --noEmit`: clean.
- `vitest list --project heavy-fs`: config parses, project resolves.
- darwin resolves to `30000` (no local behavior change); windows `120000` verified by this PR's CI.

> Foundational: once merged, the other open post-2.0.0 PRs re-run green on windows after a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-configuration only; no production code, auth, or data paths—Linux/macOS behavior unchanged.
> 
> **Overview**
> Sets the **`heavy-fs`** Vitest project **`testTimeout`** to **120s on Windows** and keeps **30s on Linux/macOS**, replacing the previous flat 30s default for that lane.
> 
> Heavy-fs tests write large temp trees; on slow **`windows-latest`** runners the heaviest init and interactive single-repo flows were intermittently hitting **"Test timed out in 30000ms"** while the same tests pass elsewhere. This centralizes headroom for all heavy-fs files instead of patching individual tests. **Per-test timeouts** (e.g. explicit 60s/120s on specific `init.test.ts` cases) still override the project default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c32b77c55b94b2729a2b5274ed92067d6da3697. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->