### PR TITLE
feat(cli): setup command, maturity prompt, picker descriptions, handoff fix (2.1.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hatch3r",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Tool-agnostic agentic coding setup: 29 agents, 53 skills, 67 rules, 30 commands, 7 hooks, MCP servers, and a CLI-tool surface generated for 3 AI coding tools from a single canonical source. Counts derived from governance/inventory.json.",
   "author": {
     "name": "hatch3r",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "hatch3r",
   "displayName": "Hatch3r",
   "description": "Agentic coding setup audited each release across 24 governance domains: 29 agents, 53 skills, 67 rules, 30 commands, 7 hooks, and MCP integrations -- in one plugin. Counts derived from governance/inventory.json.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "hatch3r"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [2.1.0] - 2026-06-26
+
+### Headline
+
+Adds a `hatch3r setup` command that scaffolds a fresh project (mkdir + git init, opt-in GitHub remote) and chains into `init`, and fixes the `/` slash-command picker showing the `HATCH3R:BEGIN` managed-block marker instead of each command/skill description across all three adapters. Interactive `init` now asks for the project maturity tier (the 4th of ≤6 prompts) and prints the defaults it inferred; `config` gains interactive maturity and `confidence_floor` steps and stops silently disabling the `handoffs` feature on re-run. No breaking CLI changes; manifest schema unchanged (schemaVersion 3).
+
+### Added
+
+- **`hatch3r setup [dir]`** — scaffold a new project then initialize it: creates the directory, runs `git init` (idempotent), optionally creates a GitHub remote with `--remote` (via `gh`, skipped with a warning when unavailable), then chains into the `init` prompts. Standard `--format <human|json>` / `--quiet` / `--dry-run` / `--verbose` flags. (CLI commands 19 → 20.)
+- **Maturity-tier prompt in `init`** — every interactive run now asks for the project maturity tier (solo / team / scaleup / enterprise), seeded at the git-inferred default; `--maturity <tier>` skips it. A matching maturity step was added to interactive `config`.
+- **`confidence_floor` step in `config`** — the agent-assertiveness floor is now settable interactively (tier-aware default), not only via `config confidence_floor=<value>`.
+- **Inferred-default feedback in `init`** — prints the default branch and maturity tier it inferred, so silent defaults are visible and correctable.
+- **`handoffs` in the `config` feature picker** — the feature is now shown and toggleable.
+
+### Fixed
+
+- **Slash-command picker descriptions** — command files (Claude Code, Cursor, Copilot) and Claude skill files now emit byte-0 YAML `description:` frontmatter, so the `/` picker shows each artifact's real description instead of the `HATCH3R:BEGIN` managed-block marker. Covers the synthetic `hatch3r-agent-team` launcher.
+- **`handoffs` silently disabled on `config` re-run** — `handoffs` was missing from the feature picker, so re-running `config` rebuilt the feature set without it and forced it off. The rebuild now preserves any feature not shown in the picker, fixing `handoffs` and preventing the same class of silent drop for future features.
+
 ## [2.0.0] - 2026-06-21
 
 ### Headline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Adds a `hatch3r setup` command that scaffolds a fresh project (mkdir + git init,
 - **Slash-command picker descriptions** — command files (Claude Code, Cursor, Copilot) and Claude skill files now emit byte-0 YAML `description:` frontmatter, so the `/` picker shows each artifact's real description instead of the `HATCH3R:BEGIN` managed-block marker. Covers the synthetic `hatch3r-agent-team` launcher.
 - **`handoffs` silently disabled on `config` re-run** — `handoffs` was missing from the feature picker, so re-running `config` rebuilt the feature set without it and forced it off. The rebuild now preserves any feature not shown in the picker, fixing `handoffs` and preventing the same class of silent drop for future features.
 
+### Chore
+
+- Post-2.0.0 housekeeping rolled into this release: D15 CI guard + npm keywords (#105), removed `release-please.yml` (org blocks Actions-created PRs) (#106), and a Windows-aware heavy-fs test timeout to stop init flakiness (#107).
+
 ## [2.0.0] - 2026-06-21
 
 ### Headline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ hatch3r is an open-source CLI (TypeScript, Commander.js) that generates tool-agn
 
 | Directory | Contents |
 |-----------|----------|
-| `src/cli/commands/` | 19 CLI commands: init, sync, status, update, validate, verify, config, clean, add, worktree-setup, worktree-cleanup, cliTools, mcp, explain, rollback, provenance, show, deps, learn <!-- count auto-derived; see governance/inventory.json (cliCommands) --> |
+| `src/cli/commands/` | 20 CLI commands: init, setup, sync, status, update, validate, verify, config, clean, add, worktree-setup, worktree-cleanup, cliTools, mcp, explain, rollback, provenance, show, deps, learn <!-- count auto-derived; see governance/inventory.json (cliCommands) --> |
 | `src/adapters/` | 3 platform adapters: cursor, claude, copilot <!-- count auto-derived; see governance/inventory.json (adapters) --> |
 | `src/pipeline/` | 22 pipeline modules: adapterTimeout, adapterToolTranslator, agentIdentity, agentToolAllowlist, checkpoint, circuitBreaker, complianceVerification, costEstimator, diffHash, failureLog, mcpDescriptionScan, observability, phaseOutputSchema, phaseTimeout, pipelineContext, pipelineTimeout, promptGuard, repoSubstitution, retryWithBackoff, reviewLoop, snapshot, spaceTelemetry <!-- count auto-derived; see governance/inventory.json (pipeline) --> |
 | `src/content/` | Content indexing, presets (minimal/standard/full), tag system |

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ hatch3r provides a full project lifecycle, from setup to release:
 
 ```bash
 npx hatch3r init          # Interactive setup (or --default for zero prompts)
+npx hatch3r setup [dir]   # Scaffold a new project (mkdir + git init) then run init
 npx hatch3r config        # Reconfigure tools, MCP servers, features, and platform
 npx hatch3r sync          # Re-generate from canonical state
 npx hatch3r update        # Pull latest templates (safe merge)

--- a/docs/marketplace-submission.md
+++ b/docs/marketplace-submission.md
@@ -77,7 +77,7 @@ The submission requires a valid `.claude-plugin/plugin.json`. The current manife
 {
   "name": "hatch3r",
   "description": "10-cycle-audited agentic coding setup: 29 agents, 53 skills, 67 rules, 30 commands, 7 hooks, and MCP integrations. Counts derived from governance/inventory.json.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "hatch3r",
     "email": "support@hatch3r.com"
@@ -170,7 +170,7 @@ cat .claude/hooks/hatch3r-hooks.json | jq .
 # Confirm inventory counts match plugin.json description
 npm run inventory && diff <(jq -r '.counts | to_entries[] | "\(.key)=\(.value)"' governance/inventory.json | sort) <(echo "agents=29
 adapters=3
-cliCommands=19
+cliCommands=20
 commands=30
 hooks=7
 pipeline=22

--- a/governance/inventory.json
+++ b/governance/inventory.json
@@ -17,7 +17,7 @@
     "commandsRevision": 4,
     "checks": 5,
     "githubAgents": 4,
-    "testFiles": 236
+    "testFiles": 237
   },
   "files": {
     "adapters": [
@@ -464,6 +464,7 @@
       "src/__tests__/adapters/mcp-utils.test.ts",
       "src/__tests__/adapters/rule-glob-resolution.test.ts",
       "src/__tests__/adapters/skillAllowedToolsGuard.test.ts",
+      "src/__tests__/adapters/skillDescriptionQuoting.test.ts",
       "src/__tests__/adapters/snapshots.test.ts",
       "src/__tests__/adapters/userContentParity.test.ts",
       "src/__tests__/archive/archive.integrityBranches.test.ts",

--- a/governance/inventory.json
+++ b/governance/inventory.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-06-11",
+  "lastUpdated": "2026-06-26",
   "counts": {
     "adapters": 3,
     "agents": 29,
@@ -10,14 +10,14 @@
     "commands": 30,
     "hooks": 7,
     "pipeline": 22,
-    "cliCommands": 19,
+    "cliCommands": 20,
     "agentsModes": 21,
     "agentsShared": 15,
     "commandsBoard": 11,
     "commandsRevision": 4,
     "checks": 5,
     "githubAgents": 4,
-    "testFiles": 235
+    "testFiles": 236
   },
   "files": {
     "adapters": [
@@ -334,6 +334,7 @@
       "mcp.ts",
       "provenance.ts",
       "rollback.ts",
+      "setup.ts",
       "show.ts",
       "status.ts",
       "sync.ts",
@@ -506,6 +507,7 @@
       "src/__tests__/cli/mcp.test.ts",
       "src/__tests__/cli/migration-checkpoints.test.ts",
       "src/__tests__/cli/rollback.test.ts",
+      "src/__tests__/cli/setup.test.ts",
       "src/__tests__/cli/shared/commandOutput.test.ts",
       "src/__tests__/cli/shared/errors.test.ts",
       "src/__tests__/cli/shared/flowSteps.parity.test.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hatch3r",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hatch3r",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "11.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hatch3r",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Agentic coding setup framework audited each release across 24 governance domains. One command to hatch your agent stack -- agents, skills, rules, commands, and MCP for Claude Code, Cursor, and GitHub Copilot.",
   "type": "module",
   "bin": {

--- a/src/__tests__/adapters/__snapshots__/snapshots.test.ts.snap
+++ b/src/__tests__/adapters/__snapshots__/snapshots.test.ts.snap
@@ -156,7 +156,7 @@ exports[`adapter output snapshots > ClaudeAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "7878ef919cc8d5c057b4f9a81fc0be4c54316cc46bff155c99e47b5d8f0a6420",
+    "bodyHash": "6dfcc96eb69c2652c26b8537473589cc6e0758715dc27935f52801dbd120f158",
     "contentMarkers": [
       "FRONTMATTER",
       "MANAGED_BLOCK",
@@ -289,7 +289,7 @@ exports[`adapter output snapshots > CopilotAdapter > output structure matches sn
   },
   {
     "action": "create",
-    "bodyHash": "4d053d2a947b87015360fee4792728b411305dfb573f73db54996e5dda1475d6",
+    "bodyHash": "8c63028845272a6142ff6b32298b34f0e3ffd16f4f6d46b40bdc28eb38b8f378",
     "contentMarkers": [
       "FRONTMATTER",
       "MANAGED_BLOCK",
@@ -540,7 +540,7 @@ exports[`adapter output snapshots > CursorAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "4d053d2a947b87015360fee4792728b411305dfb573f73db54996e5dda1475d6",
+    "bodyHash": "8c63028845272a6142ff6b32298b34f0e3ffd16f4f6d46b40bdc28eb38b8f378",
     "contentMarkers": [
       "FRONTMATTER",
       "MANAGED_BLOCK",

--- a/src/__tests__/adapters/__snapshots__/snapshots.test.ts.snap
+++ b/src/__tests__/adapters/__snapshots__/snapshots.test.ts.snap
@@ -73,8 +73,9 @@ exports[`adapter output snapshots > ClaudeAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "5b7f3d7a8b2bc9637ad66c33774a0b0082b5a78dfd72f138fbc6ca725c51a323",
+    "bodyHash": "7ed4814b45eb01509f72112e3f677a1325b0f346543992a88eb782a89a086931",
     "contentMarkers": [
+      "FRONTMATTER",
       "MANAGED_BLOCK",
     ],
     "hasManagedContent": true,
@@ -82,8 +83,9 @@ exports[`adapter output snapshots > ClaudeAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "a1d33909d7202d1cd9d939d325559c88297d10910e0448ab3e0d5594e6793dfd",
+    "bodyHash": "caaffe65856323e861f5b90f03217d1ecfe0d97670d83237c12b84168fb8084d",
     "contentMarkers": [
+      "FRONTMATTER",
       "MANAGED_BLOCK",
     ],
     "hasManagedContent": true,
@@ -154,8 +156,9 @@ exports[`adapter output snapshots > ClaudeAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "44a01c4e7a01b3ff1bb948e97220fddafdc09753d78a9bdb8247c6af1bc59b2d",
+    "bodyHash": "7878ef919cc8d5c057b4f9a81fc0be4c54316cc46bff155c99e47b5d8f0a6420",
     "contentMarkers": [
+      "FRONTMATTER",
       "MANAGED_BLOCK",
     ],
     "hasManagedContent": true,
@@ -276,8 +279,9 @@ exports[`adapter output snapshots > CopilotAdapter > output structure matches sn
   },
   {
     "action": "create",
-    "bodyHash": "75db9d5cece0faac2cae0552991a52abb3408eecbe3ff848a5a6ccfc71ee6d5b",
+    "bodyHash": "9f81e2b5a166c02f60ee288ad54e0977e308ade2696ee77af3d5f200ad4cbd99",
     "contentMarkers": [
+      "FRONTMATTER",
       "MANAGED_BLOCK",
     ],
     "hasManagedContent": true,
@@ -399,8 +403,9 @@ exports[`adapter output snapshots > CursorAdapter > output structure matches sna
   },
   {
     "action": "create",
-    "bodyHash": "75db9d5cece0faac2cae0552991a52abb3408eecbe3ff848a5a6ccfc71ee6d5b",
+    "bodyHash": "9f81e2b5a166c02f60ee288ad54e0977e308ade2696ee77af3d5f200ad4cbd99",
     "contentMarkers": [
+      "FRONTMATTER",
       "MANAGED_BLOCK",
     ],
     "hasManagedContent": true,

--- a/src/__tests__/adapters/claude.test.ts
+++ b/src/__tests__/adapters/claude.test.ts
@@ -695,6 +695,40 @@ Body.`,
     expect(skill.path).toMatch(/SKILL\.md$/);
     expect(skill.content).toContain("test-skill");
     expect(skill.managedContent).toBeDefined();
+    // Slash-command picker fix: the SKILL output now opens with YAML
+    // frontmatter. It previously did not (raw managed block whose first line
+    // was the HATCH3R:BEGIN marker, which the picker rendered as the
+    // description). The Claude adapter switched skills to the with-fm helper.
+    expect(skill.content.startsWith("---")).toBe(true);
+    expect(skill.content.startsWith(MANAGED_BLOCK_START)).toBe(false);
+    expect(skill.content).toContain("description:");
+    expect(skill.content).toContain("A test skill for unit testing");
+    const skillFm = skill.content.slice(0, skill.content.indexOf(MANAGED_BLOCK_START));
+    expect(skillFm).not.toContain("HATCH3R:BEGIN");
+  });
+
+  it("emits per-command files with description frontmatter at byte 0 (slash-picker fix)", async () => {
+    const manifest = makeManifest();
+    const outputs = await adapter.generate(FIXTURES_DIR, manifest);
+
+    // The canonical command. The synthetic .claude/commands/hatch3r-agent-team.md
+    // launcher is built inline (not via processCommandsWithFm), so target the
+    // canonical command id explicitly.
+    const cmd = outputs.find(
+      (o) => o.path === ".claude/commands/hatch3r-test-command.md",
+    );
+    expect(cmd).toBeDefined();
+    expect(cmd!.content.startsWith("---")).toBe(true);
+    expect(cmd!.content.startsWith(MANAGED_BLOCK_START)).toBe(false);
+    expect(cmd!.content).toContain("description:");
+    expect(cmd!.content).toContain("A test command for unit testing");
+    // The frontmatter block (before the managed block) carries the real
+    // description, not the HATCH3R:BEGIN marker the picker used to show.
+    const fmBlock = cmd!.content.slice(0, cmd!.content.indexOf(MANAGED_BLOCK_START));
+    expect(fmBlock).toContain("description:");
+    expect(fmBlock).not.toContain("HATCH3R:BEGIN");
+    // Cache-breakpoint post-processing still wraps the managed body.
+    expect(cmd!.managedContent).toBeDefined();
   });
 
   it("generates .mcp.json when MCP is enabled with servers", async () => {
@@ -1932,12 +1966,21 @@ Low priority rule body.
       expect(agentTeam!.content).toContain(CACHE_BREAKPOINT_SENTINEL_END);
       expect(agentTeam!.managedContent).toContain(CACHE_BREAKPOINT_SENTINEL_START);
       expect(agentTeam!.managedContent).toContain(CACHE_BREAKPOINT_SENTINEL_END);
+      // Slash-command picker fix: the synthetic launcher now opens with YAML
+      // frontmatter (byte 0) so the picker reads a real `description:` instead
+      // of the HATCH3R:BEGIN managed-block marker.
+      expect(agentTeam!.content.startsWith("---")).toBe(true);
+      expect(agentTeam!.content.startsWith(MANAGED_BLOCK_START)).toBe(false);
+      expect(agentTeam!.content).toContain("description:");
+      const agentTeamFm = agentTeam!.content.slice(0, agentTeam!.content.indexOf(MANAGED_BLOCK_START));
+      expect(agentTeamFm).toContain("description:");
+      expect(agentTeamFm).not.toContain("HATCH3R:BEGIN");
     });
 
     it("does not duplicate sentinels on re-emission (idempotent helper)", async () => {
       // Same adapter instance, two sequential generates → sentinels must
       // appear exactly once per managed block (no double-wrap from nested
-      // calls or from `processSkillsRawCliFiltered` -> `rewrapWithCacheBreakpoints`).
+      // calls or from `processSkillsWithFmCliFiltered` -> `rewrapWithCacheBreakpoints`).
       const manifest = makeManifest();
       await adapter.generate(FIXTURES_DIR, manifest);
       const outputs = await adapter.generate(FIXTURES_DIR, manifest);

--- a/src/__tests__/adapters/copilot.test.ts
+++ b/src/__tests__/adapters/copilot.test.ts
@@ -209,6 +209,61 @@ Applies to API code and protobufs.`,
     expect(promptFromCommands).toBeDefined();
     expect(promptFromCommands!.path).toBe(".github/prompts/hatch3r-test-command.prompt.md");
     expect(promptFromCommands!.managedContent).toBeDefined();
+    // Slash-command picker fix: the per-command prompt opens with YAML
+    // frontmatter so the picker reads `description:`, not the HATCH3R:BEGIN
+    // managed-block marker.
+    expect(promptFromCommands!.content.startsWith("---")).toBe(true);
+    expect(promptFromCommands!.content.startsWith(MANAGED_BLOCK_START)).toBe(false);
+    expect(promptFromCommands!.content).toContain("description:");
+    expect(promptFromCommands!.content).toContain("A test command for unit testing");
+  });
+
+  it("double-quotes command descriptions so `: `, `--`, and quotes never break the picker's YAML", async () => {
+    // Real command descriptions carry `: ` and `--` (e.g. "from the project
+    // board: dependency-aware selection") that make an UNQUOTED YAML plain
+    // scalar ambiguous/invalid — which is what made the picker fall back to
+    // showing the HATCH3R:BEGIN marker. Pin that the emitted frontmatter is a
+    // double-quoted scalar that round-trips through a real YAML parser.
+    const tempDir = await mkdtemp(join(tmpdir(), "hatch3r-copilot-cmd-fm-"));
+    try {
+      const agentsDir = join(tempDir, "agents");
+      await mkdir(join(agentsDir, "commands"), { recursive: true });
+      const nastyDesc =
+        'Design a new capability -- draft user stories: acceptance criteria, "data model", and API surface';
+      // Leading `[` would parse as a YAML flow sequence if emitted unquoted, so
+      // the argument-hint exercises the same quoting path (D5-33 affordance).
+      const nastyHint = "[target] | <id> -- mode: fast";
+      await writeFile(
+        join(agentsDir, "commands", "nasty-command.md"),
+        `---\nid: nasty-command\ntype: command\ndescription: ${JSON.stringify(nastyDesc)}\nargument-hint: ${JSON.stringify(nastyHint)}\n---\n# Nasty Command\n\nBody.`,
+        "utf-8",
+      );
+      const outputs = await adapter.generate(agentsDir, makeManifest());
+
+      const cmd = outputs.find(
+        (o) => o.path === ".github/prompts/hatch3r-nasty-command.prompt.md",
+      );
+      expect(cmd).toBeDefined();
+      expect(cmd!.content.startsWith("---")).toBe(true);
+
+      // The emitted frontmatter parses as YAML and round-trips the exact
+      // description and argument-hint; an unquoted plain scalar would have
+      // thrown or truncated at the first `: ` / `[`.
+      const fmMatch = cmd!.content.match(/^---\n([\s\S]*?)\n---/);
+      expect(fmMatch).not.toBeNull();
+      const parsed = parseYaml(fmMatch![1]) as {
+        name?: string;
+        description?: string;
+        "argument-hint"?: string;
+      };
+      expect(parsed.name).toBe("nasty-command");
+      expect(parsed.description).toBe(nastyDesc);
+      expect(parsed.description).not.toContain("HATCH3R:BEGIN");
+      // argument-hint survives at byte 0 so the picker affordance works (D5-33).
+      expect(parsed["argument-hint"]).toBe(nastyHint);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
   });
 
   it("generates regular agent files from the agents path", async () => {

--- a/src/__tests__/adapters/cursor.test.ts
+++ b/src/__tests__/adapters/cursor.test.ts
@@ -311,6 +311,15 @@ You are a test agent.`,
     expect(cmd.path).toBe(".cursor/commands/hatch3r-test-command.md");
     expect(cmd.content).toContain("test-command");
     expect(cmd.managedContent).toBeDefined();
+    // Slash-command picker fix: frontmatter at byte 0 so the picker reads
+    // `description:` rather than the HATCH3R:BEGIN managed-block marker.
+    expect(cmd.content.startsWith("---")).toBe(true);
+    expect(cmd.content.startsWith(MANAGED_BLOCK_START)).toBe(false);
+    expect(cmd.content).toContain("description:");
+    expect(cmd.content).toContain("A test command for unit testing");
+    const fmBlock = cmd.content.slice(0, cmd.content.indexOf(MANAGED_BLOCK_START));
+    expect(fmBlock).toContain("description:");
+    expect(fmBlock).not.toContain("HATCH3R:BEGIN");
   });
 
   it("generates mcp.json when MCP is enabled with servers", async () => {

--- a/src/__tests__/adapters/skillDescriptionQuoting.test.ts
+++ b/src/__tests__/adapters/skillDescriptionQuoting.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parse as parseYaml } from "yaml";
+import { ClaudeAdapter } from "../../adapters/claude.js";
+import { CursorAdapter } from "../../adapters/cursor.js";
+import { CopilotAdapter } from "../../adapters/copilot.js";
+import { createManifest } from "../../manifest/hatchJson.js";
+import type { AdapterOutput, Tool } from "../../types.js";
+
+// Skill-frontmatter quoting parity with the command helper. The Claude/Cursor/
+// Copilot adapters route skills through `processSkillsWithFmCliFiltered`, which
+// prepends a byte-0 `---\nname:\ndescription:\n---` stub so the `/` picker reads
+// the real description (not the `HATCH3R:BEGIN` managed-block marker). A skill
+// description carrying `: ` / `--` / `"` makes an UNQUOTED plain scalar invalid
+// YAML, so the picker falls back to the marker — the same failure mode already
+// fixed for command descriptions (`toYamlDoubleQuotedScalar`). The fix applies
+// that helper to the skill `description:` too; this test pins the round-trip.
+
+const SKILL_ID = "hatch3r-torture-desc";
+
+// A torture description: `: ` (mapping-key hazard), `--` (flow/double-dash),
+// and inner `"` (quote-escaping path). Staged in the canonical SKILL.md as a
+// single-quoted YAML scalar so the canonical frontmatter itself parses, then
+// re-emitted by the adapter — which must double-quote it to survive byte-0.
+const TORTURE_DESC =
+  'Reticulate splines: a dependency-aware --dry-run pass. Use "quoted" mode: yes.';
+
+/** Extract the byte-0 YAML frontmatter block (first `---` … `---`). */
+function frontmatterOf(content: string): Record<string, unknown> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error("no byte-0 frontmatter block found");
+  return (parseYaml(match[1]!) ?? {}) as Record<string, unknown>;
+}
+
+describe("skill description YAML quoting (picker safety, byte-0 frontmatter)", () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function stageTortureSkill(): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-skill-quote-"));
+    const skillDir = join(tempDir, "skills", SKILL_ID);
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, "SKILL.md"),
+      `---\nid: ${SKILL_ID}\ntype: skill\ndescription: '${TORTURE_DESC.replace(/'/g, "''")}'\ntags: [maintenance]\n---\n# Torture\n\nbody\n`,
+      "utf-8",
+    );
+    return tempDir;
+  }
+
+  const adapters: Array<{ tool: Tool; make: () => { generate: (root: string, m: ReturnType<typeof createManifest>) => Promise<AdapterOutput[]> } }> = [
+    { tool: "claude", make: () => new ClaudeAdapter() },
+    { tool: "cursor", make: () => new CursorAdapter() },
+    { tool: "copilot", make: () => new CopilotAdapter() },
+  ];
+
+  for (const { tool, make } of adapters) {
+    it(`${tool} emits a double-quoted skill description that round-trips through a YAML parser`, async () => {
+      const root = await stageTortureSkill();
+      const manifest = createManifest({ tools: [tool] });
+      const outputs = await make().generate(root, manifest);
+
+      const skillOut = outputs.find((o) => o.path.endsWith("SKILL.md"));
+      expect(skillOut, `${tool}: emitted no SKILL.md output`).toBeDefined();
+
+      // The `: `-bearing description would have produced an invalid plain
+      // scalar — the fix wraps it in double quotes at byte 0.
+      expect(skillOut!.content).toMatch(/\ndescription: "/);
+
+      // The byte-0 frontmatter parses and the description survives intact,
+      // including the `: `, `--`, and inner `"`.
+      const fm = frontmatterOf(skillOut!.content);
+      expect(fm.name).toBe(SKILL_ID);
+      expect(fm.description).toBe(TORTURE_DESC);
+    });
+  }
+});

--- a/src/__tests__/cli/__snapshots__/constants.test.ts.snap
+++ b/src/__tests__/cli/__snapshots__/constants.test.ts.snap
@@ -34,6 +34,10 @@ exports[`data constants > FEATURE_CHOICES matches snapshot 1`] = `
     "name": "GitHub agents",
     "value": "githubAgents",
   },
+  {
+    "name": "Handoffs",
+    "value": "handoffs",
+  },
 ]
 `;
 

--- a/src/__tests__/cli/commands/init.userPrompt.test.ts
+++ b/src/__tests__/cli/commands/init.userPrompt.test.ts
@@ -92,14 +92,16 @@ describe("init post-init tip", () => {
 
   it("interactive mode prints the /hatch3r-create tip exactly once", async () => {
     const inq = vi.mocked(inquirer.prompt);
-    // F10.3-2 (D10, P1): the interactive first-run flow is collapsed to the
-    // ≤5-prompt ceiling — platform, identity, preset, tools, and (W3-mcp-optin)
-    // the CLI-tools picker (pickCliTools answers under `name: "tools"`; the
-    // queue is order-based). defaultBranch / projectType / teamSize / maturity
-    // resolve from smart defaults; MCP is opt-in via --mcp, never prompted.
+    // F10.3-2 (D10, P1): the interactive first-run flow is capped at the
+    // ≤6-prompt ceiling — platform, identity, preset, maturity, tools, and
+    // (W3-mcp-optin) the CLI-tools picker (pickCliTools answers under
+    // `name: "tools"`; the queue is order-based). defaultBranch / projectType /
+    // teamSize resolve from smart defaults; MCP is opt-in via --mcp, never
+    // prompted. 2.1.0 (Decision 25) raised the ceiling 5→6 to add maturity.
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     inq.mockResolvedValueOnce({ tools: [] });
 

--- a/src/__tests__/cli/config.test.ts
+++ b/src/__tests__/cli/config.test.ts
@@ -741,6 +741,26 @@ describe("config command", () => {
       expect(writtenManifest.maturity).toBe("scaleup");
       expect(writtenManifest.confidenceFloor).toBe("high");
     });
+
+    it("dry-run preview includes the maturity dial line (Bugbot: config dry-run omits dial lines)", async () => {
+      // The live "Config updated" box appends `~ Maturity:` / `~ Confidence
+      // floor:` after buildDiffSummaryLines; the `--dry-run` terminus must show
+      // the same dial lines so the preview matches what a real run persists.
+      const manifest = makeManifest(); // no maturity field → resolves to solo
+      primeConfig(manifest, { maturity: "scaleup" });
+
+      await (await importConfigCommand())(undefined, undefined, { dryRun: true });
+
+      // Dry run writes nothing …
+      expect(vi.mocked(writeManifest)).not.toHaveBeenCalled();
+      // … and the dry-run box carries the maturity change line a live run would.
+      const dryRunBox = vi
+        .mocked(printBox)
+        .mock.calls.find((call) => call[0] === "Config dry run (no writes)");
+      expect(dryRunBox).toBeDefined();
+      const lines = dryRunBox![1] as string[];
+      expect(lines.some((l) => l.includes("Maturity: scaleup"))).toBe(true);
+    });
   });
 
   // ── MCP servers ──────────────────────────────────────────────

--- a/src/__tests__/cli/config.test.ts
+++ b/src/__tests__/cli/config.test.ts
@@ -630,6 +630,42 @@ describe("config command", () => {
       expect(result.hooks).toBe(false);   // listed + unselected → off
       expect(result.mcp).toBe(true);      // listed + selected → on
     });
+
+    it("renders Handoffs checked when the manifest OMITS the key, and keeps it enabled on accept-defaults", async () => {
+      // Upgraded manifests written before `handoffs` joined the schema omit the
+      // key entirely. DEFAULT_FEATURES.handoffs === true, so the checkbox
+      // default must fall back to the schema default and render handoffs CHECKED
+      // — otherwise an accept-defaults run rebuilds features.handoffs = false and
+      // silently disables it (the existing handoffs tests above use a manifest
+      // where the key is present, so they miss this missing-key path).
+      const manifest = makeManifest();
+      delete (manifest.features as Partial<Features>).handoffs;
+      expect(manifest.features.handoffs).toBeUndefined();
+
+      // Accept the (now-checked) default set including handoffs; adding a tool
+      // forces the write past the no-changes guard.
+      primeConfig(manifest, {
+        features: ["agents", "skills", "rules", "commands", "mcp", "githubAgents", "hooks", "handoffs"],
+        tools: ["cursor", "claude"],
+      });
+
+      await (await importConfigCommand())();
+
+      // 1. The features prompt seeded handoffs as a checked default (the fix:
+      //    `manifest.features[k] ?? DEFAULT_FEATURES[k]`). Pre-fix the missing
+      //    key read as falsy and handoffs was absent from the default set.
+      const featuresCall = vi.mocked(inquirer.prompt).mock.calls.find((call) => {
+        const questions = call[0] as unknown as PromptQuestion[];
+        return Array.isArray(questions) && questions.some((q) => q.name === "features");
+      });
+      expect(featuresCall).toBeDefined();
+      const featuresQuestion = (featuresCall![0] as unknown as Array<{ name?: string; default?: unknown }>)[0];
+      expect(featuresQuestion.default).toContain("handoffs");
+
+      // 2. The accepted selection persists handoffs enabled — no silent disable.
+      const writtenManifest = getWrittenManifest(writeManifest);
+      expect(writtenManifest.features.handoffs).toBe(true);
+    });
   });
 
   describe("maturity + confidence_floor interactive steps (Tasks C/E, 2.1.0)", () => {
@@ -675,6 +711,35 @@ describe("config command", () => {
 
       expect(vi.mocked(info)).toHaveBeenCalledWith(expect.stringContaining("No changes detected"));
       expect(vi.mocked(writeManifest)).not.toHaveBeenCalled();
+    });
+
+    it("seeds the floor default from the in-run maturity bump, not the pre-mutation tier", async () => {
+      // solo manifest, no explicit confidenceFloor → pre-mutation floor "any".
+      // Bumping maturity to scaleup in the SAME run must seed the floor prompt's
+      // default to scaleup's derived "high" (not the stale "any"), so accepting
+      // it cannot pin a floor that contradicts the new tier. The inquirer mock
+      // returns queued answers regardless of `default`, so the seed is asserted
+      // on the rendered prompt; the queued floor answer mirrors accepting it.
+      const manifest = makeManifest(); // no maturity / confidenceFloor fields
+      expect(manifest.confidenceFloor).toBeUndefined();
+      primeConfig(manifest, { maturity: "scaleup", confidenceFloor: "high" });
+
+      await (await importConfigCommand())();
+
+      const floorCall = vi.mocked(inquirer.prompt).mock.calls.find((call) => {
+        const questions = call[0] as unknown as PromptQuestion[];
+        return Array.isArray(questions) && questions.some((q) => q.name === "confidenceFloor");
+      });
+      expect(floorCall).toBeDefined();
+      const floorQuestion = (floorCall![0] as unknown as Array<{ name?: string; default?: unknown }>)[0];
+      // Pre-fix this default was readConfidenceFloor(pre-mutation solo) === "any".
+      expect(floorQuestion.default).toBe("high");
+
+      // Accepting that tier-correct default persists a floor that follows the
+      // new tier — no stale "any" pin overriding scaleup's derived "high".
+      const writtenManifest = getWrittenManifest(writeManifest);
+      expect(writtenManifest.maturity).toBe("scaleup");
+      expect(writtenManifest.confidenceFloor).toBe("high");
     });
   });
 

--- a/src/__tests__/cli/config.test.ts
+++ b/src/__tests__/cli/config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } fr
 import { mkdtemp, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { ARCHIVE_DIR, HatchError, DEFAULT_FEATURES, type HatchManifest } from "../../types.js";
+import { ARCHIVE_DIR, HatchError, DEFAULT_FEATURES, type Features, type HatchManifest } from "../../types.js";
 import {
   makeManifest,
   makeContentSelection,
@@ -589,6 +589,92 @@ describe("config command", () => {
       const writtenManifest = getWrittenManifest(writeManifest);
       expect(writtenManifest.features.hooks).toBe(false);
       expect(writtenManifest.features.mcp).toBe(false);
+    });
+  });
+
+  // ── 2.1.0: handoffs fix + maturity/confidence interactive surfaces ──
+  describe("handoffs feature-rebuild fix (Task D, 2.1.0)", () => {
+    it("FEATURE_CHOICES offers handoffs (default-checked) so it round-trips", async () => {
+      const { FEATURE_CHOICES } = await import("../../cli/shared/constants.js");
+      expect(FEATURE_CHOICES.some((c) => c.value === "handoffs")).toBe(true);
+    });
+
+    it("re-running config keeps features.handoffs === true (core regression)", async () => {
+      // makeManifest carries DEFAULT_FEATURES.handoffs === true. A tool add
+      // forces the write; the feature selection accepts the default set (which
+      // now includes handoffs as a checked choice), so handoffs survives.
+      const manifest = makeManifest();
+      primeConfig(manifest, { tools: ["cursor", "claude"] });
+
+      await (await importConfigCommand())();
+
+      const writtenManifest = getWrittenManifest(writeManifest);
+      expect(writtenManifest.features.handoffs).toBe(true);
+    });
+
+    it("rebuildFeaturesFromSelection preserves a feature absent from the picker", async () => {
+      const { rebuildFeaturesFromSelection } = await import("../../cli/commands/config.js");
+      const prev: Features = { ...DEFAULT_FEATURES, handoffs: true, mcp: true };
+      // Simulate the pre-2.1.0 picker that did NOT render handoffs.
+      const pickerVisible: (keyof Features)[] = [
+        "agents", "skills", "rules", "prompts", "commands", "mcp", "hooks", "githubAgents",
+      ];
+      // User unchecks hooks; handoffs is not offered at all.
+      const selected: (keyof Features)[] = [
+        "agents", "skills", "rules", "prompts", "commands", "mcp", "githubAgents",
+      ];
+
+      const result = rebuildFeaturesFromSelection(prev, selected, pickerVisible);
+
+      expect(result.handoffs).toBe(true); // unlisted → prior value preserved
+      expect(result.hooks).toBe(false);   // listed + unselected → off
+      expect(result.mcp).toBe(true);      // listed + selected → on
+    });
+  });
+
+  describe("maturity + confidence_floor interactive steps (Tasks C/E, 2.1.0)", () => {
+    it("the maturity step fires and persists the chosen tier", async () => {
+      const manifest = makeManifest(); // no maturity field → resolves to solo
+      primeConfig(manifest, { maturity: "scaleup" });
+
+      await (await importConfigCommand())();
+
+      // The maturity prompt was rendered.
+      const sawMaturityPrompt = vi.mocked(inquirer.prompt).mock.calls.some((call) => {
+        const questions = call[0] as unknown as PromptQuestion[];
+        return Array.isArray(questions) && questions.some((q) => q.name === "maturity");
+      });
+      expect(sawMaturityPrompt).toBe(true);
+      // The tier change alone forces the write (not gated by "No changes").
+      const writtenManifest = getWrittenManifest(writeManifest);
+      expect(writtenManifest.maturity).toBe("scaleup");
+    });
+
+    it("the confidence_floor step fires and persists the chosen floor", async () => {
+      const manifest = makeManifest(); // solo, no floor → resolves to "any"
+      primeConfig(manifest, { confidenceFloor: "high" });
+
+      await (await importConfigCommand())();
+
+      const sawFloorPrompt = vi.mocked(inquirer.prompt).mock.calls.some((call) => {
+        const questions = call[0] as unknown as PromptQuestion[];
+        return Array.isArray(questions) && questions.some((q) => q.name === "confidenceFloor");
+      });
+      expect(sawFloorPrompt).toBe(true);
+      const writtenManifest = getWrittenManifest(writeManifest);
+      expect(writtenManifest.confidenceFloor).toBe("high");
+    });
+
+    it("accepting the maturity + floor defaults registers no change", async () => {
+      // makeManifest has no maturity/floor → defaults solo/any; the queued
+      // answers mirror those defaults, so the no-changes guard still fires.
+      const manifest = makeManifest();
+      primeConfig(manifest);
+
+      await (await importConfigCommand())();
+
+      expect(vi.mocked(info)).toHaveBeenCalledWith(expect.stringContaining("No changes detected"));
+      expect(vi.mocked(writeManifest)).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/cli/index.test.ts
+++ b/src/__tests__/cli/index.test.ts
@@ -18,6 +18,9 @@ describe("createProgram() command registration", () => {
 
   const EXPECTED_COMMANDS = [
     "init",
+    // Scaffold a fresh project (mkdir + git init, optional gh remote) then
+    // chain into init.
+    "setup",
     "sync",
     "status",
     "update",
@@ -246,6 +249,7 @@ describe("W5 flag-surface drift guard", () => {
   // MUTATING: writes files / manifest / git state.
   const MUTATING = new Set<string>([
     "init",
+    "setup", // mkdir + git init (+ optional gh remote), then chains into init
     "sync",
     "update",
     "config",
@@ -280,6 +284,7 @@ describe("W5 flag-surface drift guard", () => {
   // --all/scalar args) — enforced at runtime by beginCommand's interactive gate.
   const INTERACTIVE_CAPABLE = new Set<string>([
     "init",
+    "setup", // prompts for a directory name when [dir] is omitted on a non-empty cwd
     "update",
     "config",
     "clean",
@@ -298,6 +303,7 @@ describe("W5 flag-surface drift guard", () => {
   // DRY_RUN: mutating commands where a meaningful preview exists.
   const DRY_RUN = new Set<string>([
     "init",
+    "setup", // previews the scaffold plan (create dir / git init / remote / run init)
     "sync",
     "update",
     "config",

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -840,8 +840,9 @@ describe("init resumability checkpoints (F16.1-C1)", () => {
   });
 });
 
-// F10.3-2 (D10, P1): the interactive first-run flow is capped at ≤5 prompts.
-describe("init interactive ≤5-prompt ceiling (F10.3-2)", () => {
+// F10.3-2 (D10, P1): the interactive first-run flow is capped at ≤6 prompts
+// (Decision 25 raised the ceiling 5→6 in 2.1.0 to add the maturity prompt).
+describe("init interactive ≤6-prompt ceiling (F10.3-2)", () => {
   let initCommand: (opts?: { mcp?: boolean }) => Promise<void>;
   let tempDir: string;
   let cwdSpy: MockInstance;
@@ -872,23 +873,25 @@ describe("init interactive ≤5-prompt ceiling (F10.3-2)", () => {
     await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
-  it("the common-path interactive flow consumes exactly 5 prompts (platform, identity, preset, tools, cliTools)", async () => {
+  it("the common-path interactive flow consumes exactly 6 prompts (platform, identity, preset, maturity, tools, cliTools)", async () => {
     const inq = vi.mocked(inquirer.prompt);
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
-    // W3-mcp-optin: the 5th prompt is the CLI-tools picker (pickCliTools
+    // W3-mcp-optin: the 6th prompt is the CLI-tools picker (pickCliTools
     // prompts under `name: "tools"`; the queue is order-based, so this
     // answer lands on the cliTools prompt, not the editor-tools prompt).
     inq.mockResolvedValueOnce({ tools: ["ripgrep", "jq"] });
 
     await initCommand();
 
-    // Exactly five inquirer.prompt calls — the ≤5-prompt ceiling. (No
-    // defaultBranch / projectType / teamSize / maturity / mcp prompts;
-    // those resolve to smart defaults, with MCP pure opt-in via --mcp.)
-    expect(inq.mock.calls.length).toBe(5);
+    // Exactly six inquirer.prompt calls — the ≤6-prompt ceiling. (No
+    // defaultBranch / projectType / teamSize / mcp prompts; those resolve to
+    // smart defaults, with MCP pure opt-in via --mcp. Maturity IS now prompted.)
+    expect(inq.mock.calls.length).toBe(6);
 
     const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
     // W3-mcp-optin: no MCP prompt and no --mcp flag → MCP off, no servers.
@@ -906,14 +909,16 @@ describe("init interactive ≤5-prompt ceiling (F10.3-2)", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
-    // 5th prompt: cliTools picker (empty selection → CLI tools disabled).
+    // 6th prompt: cliTools picker (empty selection → CLI tools disabled).
     inq.mockResolvedValueOnce({ tools: [] });
 
     await initCommand({ mcp: true });
 
-    // Still 5 prompts — `--mcp` resolves the server set without prompting.
-    expect(inq.mock.calls.length).toBe(5);
+    // Still 6 prompts — `--mcp` resolves the server set without prompting.
+    expect(inq.mock.calls.length).toBe(6);
     const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
     expect(manifest.features.mcp).toBe(true);
     // Platform default set: platform server first, then DEFAULT_MCP tail.
@@ -922,6 +927,146 @@ describe("init interactive ≤5-prompt ceiling (F10.3-2)", () => {
     expect(manifest.mcp.servers).toContain("context7");
     // Empty cliTools pick → disabled config.
     expect(manifest.cliTools).toEqual({ enabled: false, selected: [] });
+  });
+});
+
+// C / F (2.1.0): interactive maturity prompt + inferred-default feedback lines.
+// The maturity prompt shows on EVERY interactive run (Decision 25 raised the
+// ceiling 5→6), seeded at the git-inferred tier; only `--maturity` skips it.
+describe("init interactive maturity prompt + inferred-default feedback (C/F, 2.1.0)", () => {
+  let initCommand: (opts?: {
+    tools?: string;
+    teamSize?: string;
+    maturity?: string;
+    quiet?: boolean;
+  }) => Promise<void>;
+  let tempDir: string;
+  let cwdSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let consoleSpy: MockInstance;
+  let consoleErrorSpy: MockInstance;
+
+  beforeAll(async () => {
+    ({ initCommand } = await import("../../cli/commands/init.js"));
+  });
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-init-mat-"));
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(inquirer.prompt).mockReset();
+  });
+
+  afterEach(async () => {
+    cwdSpy.mockRestore();
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it("shows the maturity prompt seeded at the git-inferred tier (--team-size team → team seed)", async () => {
+    const inq = vi.mocked(inquirer.prompt);
+    // Order: platform, identity, preset, maturity, tools, cliTools.
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ maturity: "scaleup" });
+    inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ tools: [] });
+
+    await initCommand({ teamSize: "team" });
+
+    // 6 prompts: the maturity step is the 4th, inserted after preset.
+    expect(inq.mock.calls.length).toBe(6);
+    // The maturity prompt (4th call) is seeded at the git-inferred tier — with
+    // `--team-size team` and no `--maturity`, the seed is "team".
+    const maturityQuestion = (inq.mock.calls[3][0] as unknown as Array<{ name?: string; default?: unknown }>)[0];
+    expect(maturityQuestion.name).toBe("maturity");
+    expect(maturityQuestion.default).toBe("team");
+    // The user's pick persists.
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.maturity).toBe("scaleup");
+  });
+
+  it("the common solo flow shows the maturity prompt (seeded solo) and is 6 prompts", async () => {
+    const inq = vi.mocked(inquirer.prompt);
+    // Fresh temp dir → inferTeamSizeFromGit falls back to solo → maturity seed
+    // "solo". Order: platform, identity, preset, maturity, tools, cliTools.
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ maturity: "solo" });
+    inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ tools: [] });
+
+    await initCommand({});
+
+    expect(inq.mock.calls.length).toBe(6);
+    // The maturity prompt IS shown on the common path (Decision 25 5→6), seeded
+    // at the inferred solo tier.
+    const maturityQuestion = (inq.mock.calls[3][0] as unknown as Array<{ name?: string; default?: unknown }>)[0];
+    expect(maturityQuestion.name).toBe("maturity");
+    expect(maturityQuestion.default).toBe("solo");
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.maturity).toBe("solo");
+  });
+
+  it("--maturity skips the maturity prompt and persists the flag value (back to 5 prompts)", async () => {
+    const inq = vi.mocked(inquirer.prompt);
+    // An explicit `--maturity` is authoritative and gates the prompt off, so the
+    // flow drops back to 5 prompts (no maturity step).
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ tools: [] });
+
+    await initCommand({ teamSize: "team", maturity: "scaleup" });
+
+    expect(inq.mock.calls.length).toBe(5);
+    const sawMaturityPrompt = inq.mock.calls.some((call) =>
+      (call[0] as unknown as Array<{ name?: string }>).some((q) => q.name === "maturity"),
+    );
+    expect(sawMaturityPrompt).toBe(false);
+    const manifest = JSON.parse(await readFile(join(tempDir, AGENTS_DIR, "hatch.json"), "utf-8"));
+    expect(manifest.maturity).toBe("scaleup");
+  });
+
+  it("emits the inferred default-branch + maturity feedback lines in human mode", async () => {
+    const inq = vi.mocked(inquirer.prompt);
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ maturity: "solo" });
+    inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ tools: [] });
+
+    await initCommand({});
+
+    const stdout = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(stdout).toContain("Detected default branch:");
+    expect(stdout).toContain("Inferred maturity:");
+  });
+
+  it("suppresses the inferred-default feedback lines under --quiet (json implies quiet)", async () => {
+    const inq = vi.mocked(inquirer.prompt);
+    inq.mockResolvedValueOnce({ platform: "github" });
+    inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
+    inq.mockResolvedValueOnce({ preset: "minimal" });
+    inq.mockResolvedValueOnce({ maturity: "solo" });
+    inq.mockResolvedValueOnce({ tools: ["claude"] });
+    inq.mockResolvedValueOnce({ tools: [] });
+
+    await initCommand({ quiet: true });
+
+    const stdout = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(stdout).not.toContain("Detected default branch:");
+    expect(stdout).not.toContain("Inferred maturity:");
   });
 });
 
@@ -1420,8 +1565,11 @@ describe("init worktree generation (claude tool present)", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "test-owner", repo: "test-repo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset on every
+    // interactive run. Solo default (fresh temp dir → inferTeamSizeFromGit solo).
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools });
-    // W3-mcp-optin: 5th prompt is the cliTools picker (pickCliTools answers
+    // W3-mcp-optin: 6th prompt is the cliTools picker (pickCliTools answers
     // under `name: "tools"`; order-based queue). Empty = CLI tools disabled,
     // which also skips the detection + installer follow-ups.
     inq.mockResolvedValueOnce({ tools: [] });
@@ -1608,6 +1756,9 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "test-owner", repo: "test-repo" });
     inq.mockResolvedValueOnce({ preset: opts.preset ?? "full" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset, before the
+    // custom-items power-user prompt. Default seeded at the inferred tier.
+    inq.mockResolvedValueOnce({ maturity: opts.maturity ?? "solo" });
     if (opts.preset === "custom") {
       inq.mockResolvedValueOnce({ items: opts.customItems ?? [] });
     }
@@ -1651,6 +1802,8 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ platform: "azure-devops" });
     inq.mockResolvedValueOnce({ org: "ado-org", project: "ado-proj", repo: "ado-repo" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
@@ -1671,6 +1824,8 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ platform: "gitlab" });
     inq.mockResolvedValueOnce({ namespace: "gl-ns", project: "gl-proj" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
@@ -1692,6 +1847,8 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ owner: "", repo: "" });
     // Empty branch -> falls back to detected default ("main" via parseGitDefaultBranch)
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     // Empty tool selection -> falls back to DEFAULT_TOOLS (= ["claude"])
     inq.mockResolvedValueOnce({ tools: [] });
     // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
@@ -1729,8 +1886,10 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
-    // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
+    // W3-mcp-optin: 6th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
     inq.mockResolvedValueOnce({ tools: [] });
     // The checkExisting prompt — accept overwrite
@@ -1755,8 +1914,10 @@ describe("init interactive single-repo flow", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
-    // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
+    // W3-mcp-optin: 6th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
     inq.mockResolvedValueOnce({ tools: [] });
     // Reject overwrite
@@ -1845,6 +2006,8 @@ describe("init interactive workspace flow", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
@@ -2054,6 +2217,8 @@ describe("init eager flag validation (C8-D1-M4)", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled);
     // MCP no longer prompts — opt-in is via --mcp / `hatch3r mcp setup`.
@@ -2798,8 +2963,10 @@ describe("init tool-secret-notes ordering (C9-H32)", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
-    // W3-mcp-optin: 5th prompt is the cliTools picker (empty = disabled).
+    // W3-mcp-optin: 6th prompt is the cliTools picker (empty = disabled).
     inq.mockResolvedValueOnce({ tools: [] });
 
     // W3-mcp-optin: the notes are gated on an actual MCP opt-in (no MCP →
@@ -2818,6 +2985,8 @@ describe("init tool-secret-notes ordering (C9-H32)", () => {
     inq.mockResolvedValueOnce({ platform: "github" });
     inq.mockResolvedValueOnce({ owner: "o", repo: "r" });
     inq.mockResolvedValueOnce({ preset: "minimal" });
+    // 2.1.0 (Decision 25 5→6): maturity prompt fires after preset.
+    inq.mockResolvedValueOnce({ maturity: "solo" });
     inq.mockResolvedValueOnce({ tools: ["claude"] });
     inq.mockResolvedValueOnce({ tools: [] });
 

--- a/src/__tests__/cli/setup.test.ts
+++ b/src/__tests__/cli/setup.test.ts
@@ -1,0 +1,238 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type MockInstance,
+} from "vitest";
+import inquirer from "inquirer";
+import { execFileSync } from "node:child_process";
+import { mkdtemp, mkdir, writeFile, rm, access } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { HatchError } from "../../types.js";
+import { setupCommand } from "../../cli/commands/setup.js";
+import { initCommand } from "../../cli/commands/init.js";
+
+// Mock inquirer so the dir-name prompt branch (no [dir] + non-empty cwd) can be
+// exercised deterministically. Separator is required by other CLI shared code
+// that may be pulled into the module graph.
+vi.mock("inquirer", () => {
+  class Separator {
+    constructor(public readonly line: string) {}
+  }
+  return { default: { prompt: vi.fn(), Separator } };
+});
+
+// Mock the chained init so setup tests assert the hand-off (opts forwarding)
+// without running the real init pipeline.
+vi.mock("../../cli/commands/init.js", () => ({
+  initCommand: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock subprocess execution (git / gh) — the established repo pattern
+// (selfUpdate.test.ts, worktree). Default no-op covers `git init`; per-test
+// mockImplementation drives the gh-missing path.
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return { ...actual, execFileSync: vi.fn() };
+});
+
+describe("setup command", () => {
+  let tempDir: string;
+  let cwdSpy: MockInstance;
+  let chdirSpy: MockInstance;
+  let exitSpy: MockInstance;
+  let consoleSpy: MockInstance;
+  let consoleErrorSpy: MockInstance;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-setup-"));
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(tempDir);
+    // No-op chdir so the test process stays in a stable cwd for cleanup.
+    chdirSpy = vi.spyOn(process, "chdir").mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {
+      throw new Error("process.exit called");
+    }) as never);
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.mocked(execFileSync).mockReset().mockReturnValue(Buffer.from(""));
+    vi.mocked(inquirer.prompt).mockReset();
+    vi.mocked(initCommand).mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    cwdSpy.mockRestore();
+    chdirSpy.mockRestore();
+    exitSpy.mockRestore();
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    await rm(tempDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  /** All git/gh argv arrays seen by the execFileSync mock, for assertion. */
+  function execCalls(): { cmd: string; args: string[] }[] {
+    return vi.mocked(execFileSync).mock.calls.map((c) => ({
+      cmd: c[0] as string,
+      args: (c[1] as string[]) ?? [],
+    }));
+  }
+
+  it("creates the target directory and chains into init", async () => {
+    await setupCommand("myproj", {});
+
+    await expect(access(join(tempDir, "myproj"))).resolves.toBeUndefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs `git init` when no .git is present", async () => {
+    await setupCommand("fresh", {});
+
+    const gitInit = execCalls().find((c) => c.cmd === "git" && c.args[0] === "init");
+    expect(gitInit).toBeDefined();
+  });
+
+  it("skips `git init` when the target already has a .git directory (idempotent)", async () => {
+    await mkdir(join(tempDir, "existing", ".git"), { recursive: true });
+
+    await setupCommand("existing", {});
+
+    const gitInit = execCalls().find((c) => c.cmd === "git" && c.args[0] === "init");
+    expect(gitInit).toBeUndefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the relevant init options to initCommand", async () => {
+    await setupCommand("proj", {
+      tools: "claude",
+      preset: "minimal",
+      maturity: "team",
+      yes: true,
+      quiet: true,
+      verbose: true,
+    });
+
+    expect(initCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tools: "claude",
+        preset: "minimal",
+        maturity: "team",
+        yes: true,
+        quiet: true,
+        verbose: true,
+      }),
+    );
+  });
+
+  it("uses the current directory when the cwd is empty and no [dir] is given", async () => {
+    await setupCommand(undefined, { yes: true });
+
+    const gitInit = execCalls().find((c) => c.cmd === "git" && c.args[0] === "init");
+    expect(gitInit).toBeDefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("prompts for a directory name when the cwd is non-empty and no [dir] is given", async () => {
+    await writeFile(join(tempDir, "preexisting.txt"), "x");
+    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ dirName: "fromprompt" });
+
+    await setupCommand(undefined, {});
+
+    expect(inquirer.prompt).toHaveBeenCalledTimes(1);
+    await expect(access(join(tempDir, "fromprompt"))).resolves.toBeUndefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("--dry-run writes nothing and does not run init", async () => {
+    await setupCommand("preview", { dryRun: true });
+
+    await expect(access(join(tempDir, "preview"))).rejects.toThrow();
+    expect(initCommand).not.toHaveBeenCalled();
+    expect(vi.mocked(execFileSync)).not.toHaveBeenCalled();
+  });
+
+  it("throws FS_ERROR when the target exists and is not empty", async () => {
+    await mkdir(join(tempDir, "occupied"), { recursive: true });
+    await writeFile(join(tempDir, "occupied", "README.md"), "real content");
+
+    let thrown: unknown;
+    try {
+      await setupCommand("occupied", {});
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(HatchError);
+    expect((thrown as HatchError).errorCode).toBe("FS_ERROR");
+    expect((thrown as HatchError).exitCode).toBe(74);
+    expect(initCommand).not.toHaveBeenCalled();
+  });
+
+  it("throws FS_ERROR under --yes when the cwd is non-empty and no [dir] is given", async () => {
+    await writeFile(join(tempDir, "existing.txt"), "content");
+
+    let thrown: unknown;
+    try {
+      await setupCommand(undefined, { yes: true });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(HatchError);
+    expect((thrown as HatchError).errorCode).toBe("FS_ERROR");
+    expect(initCommand).not.toHaveBeenCalled();
+  });
+
+  it("a failing `gh repo create` warns but does not abort the scaffold", async () => {
+    // gh auth status + git succeed; gh repo create throws.
+    vi.mocked(execFileSync).mockImplementation((...callArgs: unknown[]) => {
+      const cmd = callArgs[0] as string;
+      const args = callArgs[1] as string[] | undefined;
+      if (cmd === "gh" && args?.[0] === "repo") throw new Error("gh repo create failed");
+      return Buffer.from("");
+    });
+
+    await expect(setupCommand("ghfail", { remote: true, yes: true })).resolves.toBeUndefined();
+
+    await expect(access(join(tempDir, "ghfail"))).resolves.toBeUndefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+    const warned = consoleErrorSpy.mock.calls
+      .flat()
+      .some((line) => typeof line === "string" && /remote/i.test(line));
+    expect(warned).toBe(true);
+  });
+
+  it("--remote with an available gh creates the GitHub remote", async () => {
+    // gh auth status + gh repo create succeed; git calls succeed.
+    vi.mocked(execFileSync).mockReturnValue(Buffer.from(""));
+
+    await setupCommand("withgh", { remote: true, yes: true });
+
+    const repoCreate = execCalls().find(
+      (c) => c.cmd === "gh" && c.args[0] === "repo" && c.args[1] === "create",
+    );
+    expect(repoCreate).toBeDefined();
+    expect(repoCreate!.args).toContain("withgh");
+    expect(initCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it("--remote without an available gh warns but still scaffolds + chains init", async () => {
+    // gh auth status throws (gh missing/unauthed); git calls succeed.
+    vi.mocked(execFileSync).mockImplementation((...callArgs: unknown[]) => {
+      const cmd = callArgs[0] as string;
+      if (cmd === "gh") throw new Error("gh: command not found");
+      return Buffer.from("");
+    });
+
+    await expect(setupCommand("withremote", { remote: true, yes: true })).resolves.toBeUndefined();
+
+    // Scaffold still happened.
+    await expect(access(join(tempDir, "withremote"))).resolves.toBeUndefined();
+    expect(initCommand).toHaveBeenCalledTimes(1);
+    // A warning about the skipped remote went to stderr.
+    const warnedAboutRemote = consoleErrorSpy.mock.calls
+      .flat()
+      .some((line) => typeof line === "string" && /gh|remote/i.test(line));
+    expect(warnedAboutRemote).toBe(true);
+  });
+});

--- a/src/__tests__/helpers/configHelpers.ts
+++ b/src/__tests__/helpers/configHelpers.ts
@@ -283,6 +283,18 @@ export interface PromptOverrides {
    * passing; set to `false` to exercise the abort branch.
    */
   confirmArchiveTools?: boolean;
+  /**
+   * 2.1.0 (Task C): answer to the unconditional maturity-tier step. Defaults to
+   * the manifest's persisted tier (or "solo" when absent), so accepting the
+   * default registers no change. Set a different tier to exercise persistence.
+   */
+  maturity?: "solo" | "team" | "scaleup" | "enterprise";
+  /**
+   * 2.1.0 (Task E): answer to the unconditional confidence-floor step. Defaults
+   * to the tier-aware resolved value (explicit floor, else solo/team→"any",
+   * scaleup/enterprise→"high"), so accepting the default registers no change.
+   */
+  confidenceFloor?: "any" | "medium" | "high";
 }
 
 /**
@@ -430,6 +442,18 @@ export function setupStandardPrompts(
       });
     }
   }
+
+  // 11.5. 2.1.0 (Tasks C/E): unconditional maturity + confidence-floor steps,
+  // appended to the end of the config step machine (after the content block,
+  // before the post-machine archive confirm). Default answers mirror the
+  // production defaults (readMaturityTier / readConfidenceFloor) so accepting
+  // them registers no change and the "No changes detected" path is preserved.
+  const queuedMaturity = overrides.maturity ?? manifest.maturity ?? "solo";
+  inquirerMock.prompt.mockResolvedValueOnce({ maturity: queuedMaturity });
+  const resolvedTier = manifest.maturity ?? "solo";
+  const tierFloor = resolvedTier === "scaleup" || resolvedTier === "enterprise" ? "high" : "any";
+  const queuedFloor = overrides.confidenceFloor ?? manifest.confidenceFloor ?? tierFloor;
+  inquirerMock.prompt.mockResolvedValueOnce({ confidenceFloor: queuedFloor });
 
   // 12. D10-M14 (Cycle 10): tool-removal archive confirm. Fires only when
   // the standard prompts above drop at least one tool relative to the

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 import type {
   AdapterOutput,
   CanonicalFile,
@@ -149,6 +150,59 @@ export type CompanionSubdir = (typeof KNOWN_COMPANION_SUBDIRS)[number];
 
 function defaultModelFormat(model: string): ModelFormat {
   return { text: `**Recommended model:** \`${model}\`` };
+}
+
+/**
+ * Render {@link value} as a YAML double-quoted scalar safe for a single-line
+ * frontmatter field (e.g. `description:`).
+ *
+ * Command descriptions routinely contain `: ` and `--` sequences (e.g.
+ * "Pick up epics/issues from the project board: dependency-aware selection")
+ * that make an unquoted YAML plain scalar ambiguous or invalid. When the
+ * `description:` line fails to parse, the slash-command picker in Claude Code /
+ * Cursor / Copilot falls back to showing the `HATCH3R:BEGIN` managed-block
+ * marker as the description. Double-quoting removes that hazard.
+ *
+ * Transform: collapse runs of CR/LF to a single space (a frontmatter scalar is
+ * one line), then escape backslashes FIRST and double-quotes second — order
+ * matters, because escaping `"` first would have its inserted `\` doubled by
+ * the backslash pass — then wrap in double quotes.
+ */
+function toYamlDoubleQuotedScalar(value: string): string {
+  const singleLine = value.replace(/[\r\n]+/g, " ");
+  const escaped = singleLine.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}
+
+/**
+ * Extract the canonical `argument-hint` frontmatter value from a command's raw
+ * file content, or `undefined` when absent/blank.
+ *
+ * The slash-command picker (Claude Code) renders `argument-hint:` as the
+ * expected-argument affordance (D5-33). The field is NOT on
+ * {@link CanonicalMetadata} — `parseFrontmatter`'s allowlist omits it — so the
+ * pre-fix `processCommandsRaw` only carried it through by emitting the whole
+ * raw frontmatter inside the managed block (below the byte-0 marker, where the
+ * picker could not read it). {@link processCommandsWithFm} re-parses it here
+ * and re-emits it in the byte-0 stub, the command analogue of how the skills
+ * helper preserves `allowed-tools`. Re-parsing (rather than threading a typed
+ * field) keeps the change inside the adapter layer.
+ *
+ * No try/catch (CONSTITUTION §2 P5 / `silent-failure/no-silent-catch`): every
+ * `cmd` reaching {@link processCommandsWithFm} was already parsed by the
+ * canonical reader ({@link readCanonicalFiles} runs `parseFrontmatter` → the
+ * same `yaml` parser and drops a file with invalid frontmatter before it
+ * becomes a `CanonicalFile`), so `parseYaml` on the same byte-0 `---…---` block
+ * cannot throw here. A regex miss (no frontmatter block) or a non-string/absent
+ * value returns `undefined`; if unvalidated content ever reached this helper, a
+ * YAML error would propagate loudly rather than be silently swallowed.
+ */
+function extractArgumentHint(rawContent: string): string | undefined {
+  const match = rawContent.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return undefined;
+  const parsed = parseYaml(match[1]) as Record<string, unknown> | null;
+  const hint = parsed?.["argument-hint"];
+  return typeof hint === "string" && hint.trim().length > 0 ? hint : undefined;
 }
 
 export abstract class BaseAdapter implements Adapter {
@@ -854,6 +908,57 @@ export abstract class BaseAdapter implements Adapter {
       if (skip) continue;
       const content = this.substituteCanonicalContent(raw, ctx);
       results.push(output(pathFn(cmd.id), wrapManagedFor(pathFn(cmd.id), content), content, this.singleSource(cmd)));
+    }
+    return results;
+  }
+
+  /**
+   * Process commands and output each with YAML frontmatter (`name`,
+   * `description`) prepended before the managed block, at the path returned by
+   * `pathFn`.
+   *
+   * Twin of {@link processCommandsRaw} (same user-facing canonical read,
+   * customization, token substitution, feature gate, and warnings handling) —
+   * and the command analogue of {@link processSkillsWithFm} — but emits a
+   * `---\nname:\ndescription:\n---` stub at byte 0 so the slash-command picker
+   * in Claude Code / Cursor / Copilot shows the real description instead of the
+   * `HATCH3R:BEGIN` managed-block marker (the picker reads `description:` at
+   * byte 0). It uses {@link applyCustomization} (frontmatter-stripped body),
+   * not {@link applyCustomizationRaw} (full file), so the canonical frontmatter
+   * is not re-emitted inside the managed block. The description (and any
+   * `argument-hint`) is rendered as a YAML double-quoted scalar via
+   * {@link toYamlDoubleQuotedScalar} because command descriptions routinely
+   * carry `: ` / `--`, and `argument-hint` values such as `[service-name]`
+   * would otherwise parse as a YAML flow sequence, either of which breaks an
+   * unquoted plain scalar.
+   *
+   * The canonical `argument-hint` field (when present) is re-emitted in the
+   * stub so the picker's argument affordance survives at byte 0 (D5-33) — the
+   * pre-fix `processCommandsRaw` carried it only below the marker where the
+   * picker could not read it. Other canonical command frontmatter (governance
+   * metadata like `orchestrator`/`agentPipeline`/`triage_tiers`) is
+   * intentionally NOT hoisted: it is hatch3r-authoring data with no runtime or
+   * picker consumer.
+   */
+  protected async processCommandsWithFm(
+    ctx: AdapterContext,
+    pathFn: (id: string) => string,
+  ): Promise<AdapterOutput[]> {
+    if (!ctx.features.commands) return [];
+    const results: AdapterOutput[] = [];
+    const commands = await this.readUserFacingCanonicalFiles(ctx.canonicalRoot, "commands", ctx.userRepoRoot);
+    for (const cmd of commands) {
+      this.throwIfAborted(ctx);
+      const { content: raw, skip, overrides, warnings } = await applyCustomization(ctx.projectRoot, cmd);
+      this.warnings.push(...warnings);
+      if (skip) continue;
+      const content = this.substituteCanonicalContent(raw, ctx);
+      const desc = overrides.description ?? cmd.description;
+      const fmLines = [`name: ${cmd.id}`, `description: ${toYamlDoubleQuotedScalar(desc)}`];
+      const argumentHint = extractArgumentHint(cmd.rawContent);
+      if (argumentHint) fmLines.push(`argument-hint: ${toYamlDoubleQuotedScalar(argumentHint)}`);
+      const fm = `---\n${fmLines.join("\n")}\n---`;
+      results.push(output(pathFn(cmd.id), `${fm}\n\n${wrapManagedFor(pathFn(cmd.id), content)}`, content, this.singleSource(cmd)));
     }
     return results;
   }

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -156,12 +156,14 @@ function defaultModelFormat(model: string): ModelFormat {
  * Render {@link value} as a YAML double-quoted scalar safe for a single-line
  * frontmatter field (e.g. `description:`).
  *
- * Command descriptions routinely contain `: ` and `--` sequences (e.g.
- * "Pick up epics/issues from the project board: dependency-aware selection")
- * that make an unquoted YAML plain scalar ambiguous or invalid. When the
- * `description:` line fails to parse, the slash-command picker in Claude Code /
- * Cursor / Copilot falls back to showing the `HATCH3R:BEGIN` managed-block
- * marker as the description. Double-quoting removes that hazard.
+ * Command and skill descriptions routinely contain `: ` and `--` sequences
+ * (e.g. "Pick up epics/issues from the project board: dependency-aware
+ * selection") that make an unquoted YAML plain scalar ambiguous or invalid.
+ * When the `description:` line fails to parse, the slash-command / skill picker
+ * in Claude Code / Cursor / Copilot falls back to showing the `HATCH3R:BEGIN`
+ * managed-block marker as the description. Double-quoting removes that hazard.
+ * Used by {@link processCommandsWithFm}, {@link processSkillsWithFm}, and
+ * {@link processSkillsWithFmCliFiltered}.
  *
  * Transform: collapse runs of CR/LF to a single space (a frontmatter scalar is
  * one line), then escape backslashes FIRST and double-quotes second — order
@@ -770,7 +772,19 @@ export abstract class BaseAdapter implements Adapter {
     return results;
   }
 
-  /** Process skills and output each with YAML frontmatter (name, description) at the path returned by `pathFn`. */
+  /**
+   * Process skills and output each with YAML frontmatter (`name`,
+   * `description`) at the path returned by `pathFn`.
+   *
+   * The `description:` is rendered as a YAML double-quoted scalar via
+   * {@link toYamlDoubleQuotedScalar} — the same treatment {@link processCommandsWithFm}
+   * applies to command descriptions. A skill description carrying `: ` (or a
+   * leading YAML indicator / `"` / `#`) would otherwise make the byte-0
+   * `description:` line an invalid plain scalar, and the `/` picker in Claude
+   * Code / Cursor / Copilot would fall back to showing the `HATCH3R:BEGIN`
+   * managed-block marker. `name` is the canonical id (a `hatch3r-` slug with no
+   * quoting hazard) and stays unquoted, mirroring the command helper.
+   */
   protected async processSkillsWithFm(
     ctx: AdapterContext,
     pathFn: (id: string) => string,
@@ -785,7 +799,7 @@ export abstract class BaseAdapter implements Adapter {
       if (skip) continue;
       const content = this.substituteCanonicalContent(raw, ctx);
       const desc = overrides.description ?? skill.description;
-      const fm = `---\nname: ${skill.id}\ndescription: ${desc}\n---`;
+      const fm = `---\nname: ${skill.id}\ndescription: ${toYamlDoubleQuotedScalar(desc)}\n---`;
       results.push(output(pathFn(skill.id), `${fm}\n\n${wrapManagedFor(pathFn(skill.id), content)}`, content, this.singleSource(skill)));
     }
     return results;
@@ -876,7 +890,10 @@ export abstract class BaseAdapter implements Adapter {
       if (skip) continue;
       const content = this.substituteCanonicalContent(raw, ctx);
       const desc = overrides.description ?? skill.description;
-      const fmLines = [`name: ${skill.id}`, `description: ${desc}`];
+      // Double-quote the description for the same picker-safety reason the
+      // command helper does (see {@link processSkillsWithFm}): a `: `- or
+      // `--`-bearing description breaks the byte-0 plain scalar otherwise.
+      const fmLines = [`name: ${skill.id}`, `description: ${toYamlDoubleQuotedScalar(desc)}`];
       // D9-H-6: append the Copilot `allowed-tools` pre-approval array when
       // the adapter opts in and the skill declares tools. Each entry is
       // JSON-quoted so binaries containing characters that would otherwise

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -137,9 +137,10 @@ function withCacheBreakpoints(body: string): string {
 
 /**
  * C9-M47 (P7): re-wrap an `AdapterOutput` produced by the cross-adapter
- * helpers (`processSkillsRawCliFiltered`, `processCommandsRaw`) so the
- * Claude adapter's managed-block payload carries the cache-breakpoint
- * sentinels without disturbing the shared base helpers.
+ * helpers (`processSkillsWithFmCliFiltered`, `processCommandsWithFm`,
+ * `processCompanionSubdir`) so the Claude adapter's managed-block payload
+ * carries the cache-breakpoint sentinels without disturbing the shared base
+ * helpers.
  *
  * Strategy: take the existing `managedContent` (the raw body the helper
  * passed to the managed-block wrapper), wrap it with sentinels, and rebuild
@@ -147,14 +148,29 @@ function withCacheBreakpoints(body: string): string {
  * the path-mandatory helper (D11-SA11.2-F8) keeps the marker variant correct
  * for the output's extension even though every `.claude/` output is markdown
  * today. Outputs without `managedContent` (no managed block) pass through
- * unchanged.
+ * unchanged. Any YAML frontmatter prefix the with-fm skill/command helpers
+ * prepend before the managed block is preserved (see the prefix logic below)
+ * so the slash-command picker keeps reading `description:` at byte 0.
  */
 function rewrapWithCacheBreakpoints(out: AdapterOutput): AdapterOutput {
   if (!out.managedContent) return out;
   const wrappedBody = withCacheBreakpoints(out.managedContent);
+  // Preserve any YAML frontmatter the with-fm skill/command helpers
+  // (processSkillsWithFmCliFiltered / processCommandsWithFm) prepend before the
+  // managed block. The slash-command picker reads `description:` at byte 0, so
+  // the rebuilt content MUST keep that prefix — rebuilding from the managed
+  // block alone would strip it and re-introduce the bug. The original content
+  // was composed as `${prefix}${wrapManagedFor(path, managedContent)}`;
+  // reconstruct that exact block to locate the prefix, then re-wrap the
+  // cache-breakpoint body. Raw (no-frontmatter) outputs — e.g. companion files
+  // emitted by processCompanionSubdir — yield blockIdx 0 and an empty prefix,
+  // so their behavior is byte-for-byte unchanged.
+  const originalBlock = wrapManagedFor(out.path, out.managedContent);
+  const blockIdx = out.content.indexOf(originalBlock);
+  const prefix = blockIdx > 0 ? out.content.slice(0, blockIdx) : "";
   return {
     ...out,
-    content: wrapManagedFor(out.path, wrappedBody),
+    content: `${prefix}${wrapManagedFor(out.path, wrappedBody)}`,
     managedContent: wrappedBody,
   };
 }
@@ -252,6 +268,17 @@ const AGENT_TEAMS_SECTION_MINIMAL = [
   "",
   "Use `/hatch3r-agent-team` for guided team creation.",
 ];
+
+/**
+ * Byte-0 picker description for the synthetic `.claude/commands/hatch3r-agent-team.md`
+ * launcher. The slash-command picker reads `description:` at byte 0; this
+ * inline-built command is not routed through `processCommandsWithFm`, so the
+ * description is supplied here. Kept free of `"` and `\` so it serializes as a
+ * valid YAML double-quoted scalar without escaping — the same shape
+ * `base.ts::toYamlDoubleQuotedScalar` emits for special-char-free input.
+ */
+const AGENT_TEAM_DESCRIPTION =
+  "Launch a Claude Code Agent Team that runs the hatch3r 4-phase pipeline — Research, Implement, Review, then parallel Quality gates — across coordinating teammates.";
 
 const AGENT_TEAM_COMMAND = `# hatch3r Agent Team
 
@@ -1221,13 +1248,13 @@ export class ClaudeAdapter extends BaseAdapter {
     // (shared across all 3 supported adapters); we post-process the
     // Claude-specific results so the sentinels appear in this adapter's
     // managed blocks only, without touching the cross-adapter helpers.
-    const skillOutputs = await this.processSkillsRawCliFiltered(
+    const skillOutputs = await this.processSkillsWithFmCliFiltered(
       ctx,
       (id) => `.claude/skills/${toPrefixedId(id)}/SKILL.md`,
     );
     results.push(...skillOutputs.map(rewrapWithCacheBreakpoints));
 
-    const commandOutputs = await this.processCommandsRaw(
+    const commandOutputs = await this.processCommandsWithFm(
       ctx,
       (id) => `.claude/commands/${toPrefixedId(id)}.md`,
     );
@@ -1329,7 +1356,17 @@ export class ClaudeAdapter extends BaseAdapter {
 
     // C9-M47 (P7): agent-team command body gets cache-breakpoint sentinels too.
     const agentTeamBody = withCacheBreakpoints(AGENT_TEAM_COMMAND);
-    results.push(output(".claude/commands/hatch3r-agent-team.md", wrapManagedFor(".claude/commands/hatch3r-agent-team.md", agentTeamBody), agentTeamBody));
+    const agentTeamPath = ".claude/commands/hatch3r-agent-team.md";
+    // Prepend byte-0 YAML frontmatter before the managed block so the
+    // slash-command picker shows AGENT_TEAM_DESCRIPTION instead of the
+    // HATCH3R:BEGIN marker. Mirrors the `${fm}\n\n${managed-block}` composition
+    // processCommandsWithFm uses; managedContent stays the cache-wrapped body.
+    const agentTeamFm = `---\nname: hatch3r-agent-team\ndescription: "${AGENT_TEAM_DESCRIPTION}"\n---`;
+    results.push(output(
+      agentTeamPath,
+      `${agentTeamFm}\n\n${wrapManagedFor(agentTeamPath, agentTeamBody)}`,
+      agentTeamBody,
+    ));
 
     return results;
   }

--- a/src/adapters/copilot.ts
+++ b/src/adapters/copilot.ts
@@ -507,7 +507,7 @@ jobs:
     // Commands still surface in Copilot's native prompts-file picker via the
     // `.github/prompts/` path below, gated on `features.commands`.
     results.push(
-      ...await this.processCommandsRaw(ctx, (id) => `.github/prompts/${toPrefixedId(id)}.prompt.md`),
+      ...await this.processCommandsWithFm(ctx, (id) => `.github/prompts/${toPrefixedId(id)}.prompt.md`),
     );
 
     // D5-41 (Cycle 11 Wave 3, D5, P4 / D16.3 add-vs-remove bias): suppress the

--- a/src/adapters/cursor.ts
+++ b/src/adapters/cursor.ts
@@ -273,7 +273,7 @@ export class CursorAdapter extends BaseAdapter {
     );
 
     results.push(
-      ...await this.processCommandsRaw(ctx, (id) => `.cursor/commands/${toPrefixedId(id)}.md`),
+      ...await this.processCommandsWithFm(ctx, (id) => `.cursor/commands/${toPrefixedId(id)}.md`),
     );
 
     // Companion/reference content (see `BaseAdapter.processCompanionSubdir`

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -995,9 +995,17 @@ async function configCommandImpl(
     {
       id: "features",
       async run(_state, previous): Promise<StepResult<(keyof Features)[]>> {
+        // A manifest written before a feature joined the schema OMITS its key;
+        // DEFAULT_FEATURES treats a missing key as its schema default (e.g.
+        // `handoffs === true`). Fall back to that default instead of the falsy
+        // `undefined` — otherwise the checkbox renders the feature UNCHECKED and
+        // an accept-defaults run persists it `false`, silently disabling it on
+        // upgraded manifests (Cursor Bugbot — handoffs default unchecked).
         const currentFeatureKeys =
           previous ??
-          (Object.keys(DEFAULT_FEATURES) as (keyof Features)[]).filter((k) => manifest.features[k]);
+          (Object.keys(DEFAULT_FEATURES) as (keyof Features)[]).filter(
+            (k) => manifest.features[k] ?? DEFAULT_FEATURES[k],
+          );
         const featureAnswers = await inquirer.prompt<{ features: (keyof Features)[] | typeof BACK }>([
           {
             type: "checkbox",
@@ -1074,15 +1082,19 @@ async function configCommandImpl(
       defaultMaturity: readMaturityTier(manifest),
     }),
     // E (2.1.0, P1): interactive confidence_floor surface — parity with the
-    // scalar `config confidence_floor=<v>` form. Default = the tier-aware
-    // resolved value (readConfidenceFloor: explicit floor wins, else
-    // solo/team→"any", scaleup/enterprise→"high"). Computed from the manifest
-    // as it stands at config start (the machine does not mutate it), so a
-    // maturity change made earlier in this same run is not reflected in this
-    // default — the user can still pick any floor explicitly.
+    // scalar `config confidence_floor=<v>` form. The default is resolved AT
+    // PROMPT TIME from the in-run maturity (`state.maturity`, set by the
+    // maturity step sequenced just above) rather than the pre-mutation
+    // manifest, so a solo→scaleup bump made earlier in this same run seeds the
+    // tier-correct floor ("high") instead of the stale solo default ("any").
+    // readConfidenceFloor keeps an explicit persisted floor winning; only the
+    // tier-derived fallback follows the new maturity. Without this, accepting
+    // the seeded default after a maturity bump would persist a floor that
+    // contradicts the chosen tier (Cursor Bugbot — floor pinned on tier bump).
     confidenceFloorStep<ConfigState>({
       message: "Agent assertiveness floor (review/ASK gate):",
-      defaultFloor: readConfidenceFloor(manifest),
+      defaultFloor: (state) =>
+        readConfidenceFloor({ ...manifest, maturity: state.maturity ?? manifest.maturity }),
     }),
   ];
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1372,6 +1372,16 @@ async function configCommandImpl(
   // `.env.mcp`, and the workspace post-steps.
   if (cliOpts?.dryRun === true) {
     const dryLines = buildDiffSummaryLines(diff, platform, namespace, project, defaultBranch, currentBranch);
+    // C / E (2.1.0, P1): mirror the live "Config updated" box's investment-dial
+    // change lines (computeDiff does not track these dials) so the dry-run
+    // preview shows the maturity / confidence-floor edits a real run would
+    // persist. Same flags + line format as the live summary path below.
+    if (maturityChanged && selectedMaturity !== undefined) {
+      dryLines.push(`${chalk.cyan("~")} Maturity: ${selectedMaturity}`);
+    }
+    if (confidenceFloorChanged && selectedConfidenceFloor !== undefined) {
+      dryLines.push(`${chalk.cyan("~")} Confidence floor: ${selectedConfidenceFloor}`);
+    }
     dryLines.push("");
     dryLines.push(
       chalk.dim(

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -59,8 +59,10 @@ import {
 } from "../shared/initSteps.js";
 import {
   cliToolsStep,
+  confidenceFloorStep,
   customItemsStep,
   identityStep,
+  maturityStep,
   mcpGateStep,
   mcpServersStep,
   platformStep,
@@ -181,6 +183,34 @@ function isDiffEmpty(diff: ConfigDiff): boolean {
     diff.addedCliTools.length === 0 &&
     diff.removedCliTools.length === 0
   );
+}
+
+/**
+ * Task D (2.1.0, CQ8 maintainability): rebuild the {@link Features} map from an
+ * interactive checkbox selection without dropping live-but-unlisted features.
+ *
+ * The config feature picker renders only the features in
+ * {@link FEATURE_CHOICES}, so the rebuild must flip ONLY the keys the picker
+ * actually offered (`pickerVisible`) and RETAIN every other key from the prior
+ * manifest. The pre-2.1.0 loop flipped EVERY {@link DEFAULT_FEATURES} key to
+ * `selected.includes(k)`, which forced any feature absent from the picker to
+ * `false` on every config run — silently disabling `handoffs` (a live control
+ * surface, `DEFAULT_FEATURES.handoffs === true`) because it was not a choice.
+ *
+ * `prev` seeds the result so unlisted keys survive; spreading over
+ * {@link DEFAULT_FEATURES} first fills any key a legacy manifest omits. Exported
+ * for direct unit testing with a synthetic unlisted feature.
+ */
+export function rebuildFeaturesFromSelection(
+  prev: Features,
+  selected: (keyof Features)[],
+  pickerVisible: Iterable<keyof Features>,
+): Features {
+  const features: Features = { ...DEFAULT_FEATURES, ...prev };
+  for (const k of pickerVisible) {
+    features[k] = selected.includes(k);
+  }
+  return features;
 }
 
 /**
@@ -898,6 +928,11 @@ async function configCommandImpl(
     worktreeEnabled: boolean;
     preset: PresetId;
     customItems: string[] | undefined;
+    // C / E (2.1.0): investment-calibration dials. Both unconditional steps,
+    // seeded from the persisted manifest via readMaturityTier /
+    // readConfidenceFloor (the latter tier-aware). Persisted after the machine.
+    maturity: MaturityTier;
+    confidenceFloor: ConfidenceFloor;
   }
 
   // W2-flowsteps: shared prompt steps are composed from the builders in
@@ -1031,6 +1066,24 @@ async function configCommandImpl(
       extraSkip: () => !manifest.content,
       wslTheme,
     }),
+    // C (2.1.0, P1): interactive maturity surface — parity with the scalar
+    // `config maturity=<tier>` form. Default = the persisted tier
+    // (readMaturityTier resolves absence to "solo").
+    maturityStep<ConfigState>({
+      message: "Maturity tier (investment depth):",
+      defaultMaturity: readMaturityTier(manifest),
+    }),
+    // E (2.1.0, P1): interactive confidence_floor surface — parity with the
+    // scalar `config confidence_floor=<v>` form. Default = the tier-aware
+    // resolved value (readConfidenceFloor: explicit floor wins, else
+    // solo/team→"any", scaleup/enterprise→"high"). Computed from the manifest
+    // as it stands at config start (the machine does not mutate it), so a
+    // maturity change made earlier in this same run is not reflected in this
+    // default — the user can still pick any floor explicitly.
+    confidenceFloorStep<ConfigState>({
+      message: "Agent assertiveness floor (review/ASK gate):",
+      defaultFloor: readConfidenceFloor(manifest),
+    }),
   ];
 
   const stepState = await runStepMachine<ConfigState>(steps);
@@ -1039,6 +1092,20 @@ async function configCommandImpl(
   const { owner, repo, namespace, project } = stepState.identity;
   const defaultBranch = stepState.defaultBranch;
   const tools = stepState.tools;
+
+  // C / E (2.1.0): detect maturity / confidence-floor changes against the
+  // pre-mutation manifest (readMaturityTier / readConfidenceFloor resolve the
+  // current effective value). computeDiff() does not track these dials, so the
+  // booleans feed the no-changes early-return guard below — without them a
+  // maturity-only or floor-only change would hit "No changes detected" and be
+  // dropped before writeManifest.
+  const selectedMaturity = stepState.maturity;
+  const selectedConfidenceFloor = stepState.confidenceFloor;
+  const maturityChanged =
+    selectedMaturity !== undefined && selectedMaturity !== readMaturityTier(manifest);
+  const confidenceFloorChanged =
+    selectedConfidenceFloor !== undefined &&
+    selectedConfidenceFloor !== readConfidenceFloor(manifest);
 
   if (tools.length === 0) {
     logError("At least one tool must be selected.");
@@ -1069,11 +1136,16 @@ async function configCommandImpl(
   };
 
   // --- Features ---
-  const selectedFeatures = stepState.features;
-  const features: Features = { ...DEFAULT_FEATURES };
-  for (const k of Object.keys(features) as (keyof Features)[]) {
-    features[k] = selectedFeatures.includes(k);
-  }
+  // Task D (2.1.0, CQ8): the checkbox only renders the features in
+  // FEATURE_CHOICES, so a feature ABSENT from the picker must RETAIN its prior
+  // manifest value — not be forced false (the pre-2.1.0 `handoffs` bug, now also
+  // listed in FEATURE_CHOICES). Logic single-sourced in the exported pure
+  // helper below so it is unit-testable with a synthetic unlisted feature.
+  const features: Features = rebuildFeaturesFromSelection(
+    manifest.features,
+    stepState.features,
+    FEATURE_CHOICES.map((c) => c.value),
+  );
 
   // --- MCP servers ---
   // When the mcp feature is on but the user declined the gate, preserve
@@ -1266,7 +1338,13 @@ async function configCommandImpl(
   // into computeDiff instead of patching the returned struct afterwards.
   const diff = computeDiff(manifest, tools, features, mcpServers, platform, owner, repo, namespace, project, selectedCliTools, contentChanges);
 
-  if (isDiffEmpty(diff) && defaultBranch === currentBranch && !contentMetadataChanged) {
+  if (
+    isDiffEmpty(diff) &&
+    defaultBranch === currentBranch &&
+    !contentMetadataChanged &&
+    !maturityChanged &&
+    !confidenceFloorChanged
+  ) {
     // W5-bigfour: blank-line separators are stdout chrome — gate behind quiet
     // (info() is already self-gated).
     if (!isQuiet()) console.log();
@@ -1412,6 +1490,12 @@ async function configCommandImpl(
   manifest.features = features;
   manifest.mcp = { servers: mcpServers };
   manifest.cliTools = cliToolsConfig;
+  // C / E (2.1.0): persist the investment dials from the interactive steps
+  // (parity with the scalar `config maturity=` / `config confidence_floor=`
+  // setters). Both steps are unconditional, so stepState always carries a
+  // value; the guard is defensive against a future skip predicate.
+  if (selectedMaturity !== undefined) manifest.maturity = selectedMaturity;
+  if (selectedConfidenceFloor !== undefined) manifest.confidenceFloor = selectedConfidenceFloor;
 
   if (manifest.board) {
     manifest.board.owner = owner;
@@ -1519,6 +1603,15 @@ async function configCommandImpl(
   // W5-bigfour: the per-change diff lines are single-sourced in
   // buildDiffSummaryLines (shared with the `--dry-run` terminus above).
   const summaryLines: string[] = buildDiffSummaryLines(diff, platform, namespace, project, defaultBranch, currentBranch);
+
+  // C / E (2.1.0, P1): surface the investment-dial changes in the summary so a
+  // maturity / floor edit is visible (computeDiff does not track these dials).
+  if (maturityChanged && selectedMaturity !== undefined) {
+    summaryLines.push(`${chalk.cyan("~")} Maturity: ${selectedMaturity}`);
+  }
+  if (confidenceFloorChanged && selectedConfidenceFloor !== undefined) {
+    summaryLines.push(`${chalk.cyan("~")} Confidence floor: ${selectedConfidenceFloor}`);
+  }
 
   summaryLines.push("");
   summaryLines.push(label("Files", `${updateResult.copiedFiles} canonical files updated`));

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -75,6 +75,7 @@ import {
   cliToolsStep,
   customItemsStep,
   identityStep,
+  maturityStep,
   platformStep,
   presetStep,
   toolsStep,
@@ -481,9 +482,11 @@ function deriveWorkspacePlatform(identities: Array<{ platform: Platform }>): Pla
 
 /**
  * F10.3-2 (D10, P1): infer team size from git history instead of prompting.
- * The interactive `teamSize` prompt was dropped to bring the first-run flow to
- * the P1 ≤5-prompt ceiling (Decision 25 / Vercel-Heroku benchmark). We count
- * distinct commit authors via `git log` — `>1` distinct author email implies a
+ * The interactive `teamSize` prompt was dropped to keep the first-run flow
+ * within the P1 prompt ceiling (Decision 25 / Vercel-Heroku benchmark; the
+ * ceiling is ≤6 as of 2.1.0, the 6th being the maturity prompt). teamSize is
+ * still inferred, not prompted. We count distinct commit authors via `git log`
+ * — `>1` distinct author email implies a
  * `team` repo; a single author (or an unreadable / empty / non-git history)
  * falls back to `solo`, which matches the prior prompt default and the `--yes`
  * default. Degradation mirrors `parseGitDefaultBranch`: any git error returns
@@ -2395,10 +2398,12 @@ export async function initCommand(
     : undefined;
   const toolDefaults = repoInfo.existingTools.length > 0 ? repoInfo.existingTools : DEFAULT_TOOLS;
 
-  // F10.3-2 (D10, P1): smart defaults for the four prompts dropped to reach
-  // the ≤5-prompt ceiling. Each value is computed from detection / git so the
-  // resolved selection is identical to what the dropped prompt would have
-  // defaulted to; every value is overridable post-init via `hatch3r config`.
+  // F10.3-2 (D10, P1): smart defaults for the prompts dropped to reach the
+  // ≤6-prompt ceiling (defaultBranch / projectType / teamSize / mcp; 2.1.0
+  // re-added maturity as a prompt seeded by `inferredMaturity` below). Each
+  // value is computed from detection / git so the resolved selection matches
+  // what the dropped prompt would have defaulted to; every value is overridable
+  // post-init via `hatch3r config`.
   const inferredDefaultBranch = parseGitDefaultBranch();
   const inferredProjectType: "greenfield" | "brownfield" = validateFlag(
     opts.projectType,
@@ -2413,16 +2418,16 @@ export async function initCommand(
     inferTeamSizeFromGit(rootDir),
     "team-size",
   );
-  // D14-17 (D14-SA14.3-F4, P1): maturity tier is not a prompted input under the
-  // ≤5-prompt ceiling, so without a seed it silently defaulted to
-  // DEFAULT_MATURITY_TIER ("solo") for every repo — a multi-author codebase got
-  // the lowest-investment calibration. `inferTeamSizeFromGit` already
-  // distinguishes solo vs multi-author by distinct commit-author count; reuse
-  // that orthogonal signal to seed the maturity default (team-authored repo →
-  // "team" tier, otherwise "solo"). An explicit `--maturity` flag still wins
-  // (validateFlag returns the flag value when present), and the resolved tier is
-  // surfaced in the success-box "Maturity" line below so the inference is
-  // visible, not silent. This keeps the solo path at ≤5 prompts (no new prompt).
+  // D14-17 (D14-SA14.3-F4, P1; 2.1.0 Decision 25 5→6): the maturity tier is now
+  // a prompted input on every interactive run (unless `--maturity` is passed),
+  // seeded by this value. `inferTeamSizeFromGit` distinguishes solo vs
+  // multi-author by distinct commit-author count; reuse that orthogonal signal
+  // to seed the maturity DEFAULT (team-authored repo → "team" tier, otherwise
+  // "solo") so the prompt's pre-selected option matches the repo. An explicit
+  // `--maturity` flag still wins (validateFlag returns the flag value when
+  // present) AND skips the prompt; on the headless / `--yes` paths this seed is
+  // the resolved tier directly. The resolved tier is surfaced in the
+  // success-box "Maturity" line.
   const seededMaturityDefault: MaturityTier =
     inferredTeamSize === "team" ? "team" : DEFAULT_MATURITY_TIER;
   const inferredMaturity: MaturityTier = validateFlag(
@@ -2431,6 +2436,31 @@ export async function initCommand(
     seededMaturityDefault,
     "maturity",
   );
+
+  // Task F (2.1.0, P1): the default branch + git-inferred team-size/maturity
+  // were resolved silently above. Surface ONE dim confirmation line each so the
+  // inference is visible before the picker, not a hidden default. `info()` is a
+  // no-op under --quiet (and --json sets quiet), so these render only in human
+  // interactive mode — the inference outcome is observable without chrome in
+  // the structured/quiet paths.
+  info(chalk.dim(`Detected default branch: ${inferredDefaultBranch}`));
+  info(
+    chalk.dim(
+      opts.maturity === undefined
+        ? `Inferred maturity: ${inferredMaturity} (team size: ${inferredTeamSize})`
+        : `Maturity: ${inferredMaturity} (from --maturity); team size: ${inferredTeamSize}`,
+    ),
+  );
+
+  // C (2.1.0, P1; Decision 25 raised the ceiling 5→6): the maturity tier is a
+  // first-class calibration input, prompted on EVERY interactive run. The only
+  // skips are `--maturity` (the flag is authoritative) and the headless /
+  // `--yes` / `--quick` / `--default` paths, which return before this block.
+  // The prompt is seeded at the git-inferred tier (`inferredMaturity`), so
+  // enter-through reproduces the prior smart default; the success-box
+  // "Maturity" line still surfaces the resolved tier.
+  const promptMaturity = opts.maturity === undefined;
+
   // W3-mcp-optin: `--cli-tools` / `--no-cli-tools` apply on the interactive
   // path too (flag semantics are path-independent). An explicit selection
   // skips the picker step below; without a flag the picker runs with tier-1 +
@@ -2445,23 +2475,28 @@ export async function initCommand(
   // pre-Slice-E inline prompts used so existing test queues match
   // unchanged. The orchestrator awaits `runStepMachine` and consumes
   // the resolved state below.
-  // F10.3-2 (D10, P1): the interactive first-run flow is capped at ≤5 prompts
-  // (Decision 25 / Vercel-Heroku OSS-onboarding benchmark). The five retained
-  // prompts are: platform, identity, preset, tools, and the CLI-tools picker
+  // F10.3-2 (D10, P1): the interactive first-run flow is capped at ≤6 prompts
+  // (Decision 25 / Vercel-Heroku OSS-onboarding benchmark; raised 5→6 in 2.1.0
+  // to add the maturity calibration prompt). The six retained prompts are:
+  // platform, identity, preset, maturity, tools, and the CLI-tools picker
   // (W3-mcp-optin: the collapsed MCP multi-select moved behind the `--mcp`
-  // flag / `hatch3r mcp setup` side-door, freeing the slot). The dropped
-  // prompts use smart defaults, each overridable post-init:
+  // flag / `hatch3r mcp setup` side-door). The dropped prompts use smart
+  // defaults, each overridable post-init:
   //   - defaultBranch → `parseGitDefaultBranch()` (git-detected)
   //   - projectType   → `detectProjectType()` (auto-detected)
   //   - teamSize      → `inferTeamSizeFromGit()` (recommendation step d)
-  //   - maturity      → `--maturity` flag / DEFAULT_MATURITY_TIER (2.0.0 add)
   //   - mcp           → off unless `--mcp` (opt in later via `hatch3r mcp setup`)
   // `customItems` stays as a conditional power-user prompt (preset=custom only),
-  // so it does not count against the common-path ceiling.
+  // so it does not count against the common-path ceiling. The maturity prompt
+  // is skipped only when `--maturity` resolved the tier from the flag.
   interface SingleRepoState {
     platform: Platform;
     identity: { owner: string; repo: string; namespace: string; project: string };
     preset: PresetId;
+    // C (2.1.0): maturity tier, prompted on every interactive run (see
+    // `promptMaturity` above). Undefined only when `--maturity` gated the prompt
+    // off — the resolved tier then falls back to `inferredMaturity` below.
+    maturity: MaturityTier;
     customItems: string[] | undefined;
     tools: Tool[];
     // W3-mcp-optin: 3-tier CLI-tools picker result. Empty selection = CLI
@@ -2505,6 +2540,19 @@ export async function initCommand(
           ),
         ),
     }),
+    // C (2.1.0, P1): maturity prompt, seeded at the git-inferred tier. Always
+    // shown on the interactive path; conditionally spread (matching the
+    // cliToolsStep gate below) only so it is ABSENT from the array — not just
+    // skipped — when `--maturity` resolved the tier from the flag. Decision 25
+    // raised the interactive ceiling 5→6 to admit it; see `promptMaturity`.
+    ...(promptMaturity
+      ? [
+          maturityStep<SingleRepoState>({
+            message: "Project maturity (investment depth):",
+            defaultMaturity: inferredMaturity,
+          }),
+        ]
+      : []),
     customItemsStep<SingleRepoState>({
       index: filterIndex,
       // D10-13: floor + protected rows are locked-on by the picker itself;
@@ -2546,7 +2594,9 @@ export async function initCommand(
   const defaultBranch = inferredDefaultBranch;
   const projectType = inferredProjectType;
   const teamSize = inferredTeamSize;
-  const maturity: MaturityTier = inferredMaturity;
+  // C (2.1.0): use the prompted tier when the maturity step ran (the common
+  // interactive path); otherwise (`--maturity` flag) the value inferred above.
+  const maturity: MaturityTier = stepState.maturity ?? inferredMaturity;
   const selectedPreset = getPreset(stepState.preset);
   const customSelections = stepState.customItems;
   const tools = stepState.tools;
@@ -2975,9 +3025,13 @@ async function runWorkspaceInit(
     const wsDetection = await detectProjectType(repoInfo, rootDir);
     const wsToolDefaults = repoInfo.existingTools.length > 0 ? repoInfo.existingTools : DEFAULT_TOOLS;
 
-    // F10.3-2 (D10, P1): workspace flow mirrors the single-repo ≤5-prompt
-    // collapse. projectType / teamSize / maturity / cliTools are no longer
-    // prompted — they resolve to detection / git-inference / flag defaults.
+    // F10.3-2 (D10, P1): workspace flow keeps the single-repo prompt-collapse.
+    // projectType / teamSize / maturity / cliTools are NOT prompted here — they
+    // resolve to detection / git-inference / flag defaults. NOTE: unlike the
+    // single-repo flow (which re-added the maturity prompt in 2.1.0, Decision 25
+    // 5→6), the workspace flow does NOT prompt maturity; it stays leaner and the
+    // tier resolves to the inferred/flag default. Re-deciding this is a behavior
+    // change for the workspace machine (wsSteps below), out of scope here.
     const wsInferredProjectType: "greenfield" | "brownfield" = validateFlag(
       opts.projectType,
       ["greenfield", "brownfield"],

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1,0 +1,260 @@
+import { execFileSync } from "node:child_process";
+import { access, mkdir, readdir } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import chalk from "chalk";
+import inquirer from "inquirer";
+import { HatchError } from "../../types.js";
+import { beginCommand, finishCommand } from "../shared/commandOutput.js";
+import { info, verbose, warn } from "../shared/ui.js";
+import { initCommand } from "./init.js";
+
+/**
+ * `hatch3r setup [dir]` — scaffold a fresh project directory (mkdir + git init,
+ * optional GitHub remote) and then chain into the standard `hatch3r init`
+ * prompting flow inside that directory. This is a regular CLI command (like
+ * `init` / `sync`), NOT a canonical `commands/hatch3r-*.md` content artifact.
+ *
+ * The happy path needs only Node 22+ and `git` — `--remote` (GitHub remote via
+ * `gh repo create`) is opt-in and degrades to a warning (never aborts the
+ * scaffold) when the GitHub CLI is missing or unauthenticated.
+ */
+export interface SetupOptions {
+  /**
+   * Opt-in: create a GitHub remote via `gh repo create` after `git init`. Only
+   * acts when `gh` is installed AND authenticated (`gh auth status` exits 0);
+   * otherwise a warning is emitted and the local scaffold continues.
+   */
+  remote?: boolean;
+  /** Forwarded to `initCommand`: comma-separated tool list. */
+  tools?: string;
+  /** Forwarded to `initCommand`: content preset. */
+  preset?: string;
+  /** Forwarded to `initCommand`: maturity tier. */
+  maturity?: string;
+  /** Forwarded to `initCommand`: skip interactive prompts / headless run. */
+  yes?: boolean;
+  /** Forwarded to `initCommand`: suppress stdout chrome. */
+  quiet?: boolean;
+  /** Forwarded to `initCommand`: `--format <human|json>`. */
+  format?: string;
+  /** Forwarded to `initCommand`: verbose per-step output. */
+  verbose?: boolean;
+  /** Preview only: print the scaffold plan and run `init` would-run; write nothing. */
+  dryRun?: boolean;
+}
+
+/**
+ * Directory entries that do NOT make a target "non-empty" for the overwrite
+ * guard. A lone `.git` is a VCS skeleton, not project content — treating it as
+ * empty lets `hatch3r setup myrepo` run idempotently against a `git init`'d but
+ * otherwise empty directory (git init is then skipped — see `gitDirExists`).
+ */
+const EMPTINESS_IGNORED_ENTRIES = new Set([".git"]);
+
+/** True when `p` exists on disk (file or directory). */
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch (err) {
+    // Absence is the expected case for a not-yet-created target; surface the
+    // reason under --verbose so a real failure (e.g. EACCES) stays observable
+    // rather than collapsing silently into "does not exist".
+    verbose(`setup: path probe access(${p}) → ${(err as NodeJS.ErrnoException).code ?? "absent"}`);
+    return false;
+  }
+}
+
+/**
+ * True when `dir` does not exist or contains nothing beyond
+ * {@link EMPTINESS_IGNORED_ENTRIES}. A missing directory is "empty" so callers
+ * can create it.
+ */
+async function isDirEffectivelyEmpty(dir: string): Promise<boolean> {
+  try {
+    const entries = await readdir(dir);
+    return entries.every((e) => EMPTINESS_IGNORED_ENTRIES.has(e));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw err;
+  }
+}
+
+/** Run `git <args>` in `cwd`, inheriting nothing to stdout (output captured). */
+function runGit(args: string[], cwd: string): void {
+  execFileSync("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+}
+
+/**
+ * True when the GitHub CLI is installed AND authenticated. `gh auth status`
+ * exits 0 only when a logged-in account exists; a missing binary throws
+ * (ENOENT) and an unauthenticated CLI exits non-zero — both resolve to `false`
+ * so `--remote` degrades to a warning rather than aborting the scaffold.
+ */
+function isGhReady(): boolean {
+  try {
+    execFileSync("gh", ["auth", "status"], { stdio: ["ignore", "pipe", "pipe"] });
+    return true;
+  } catch (err) {
+    verbose(`setup: gh availability probe failed — ${err instanceof Error ? err.message : String(err)}`);
+    return false;
+  }
+}
+
+/**
+ * Resolve the target directory NAME. Precedence:
+ *   1. Explicit positional `dir`.
+ *   2. `.` (current directory) when the cwd is effectively empty.
+ *   3. `.` under `--yes` (headless cannot prompt — the overwrite guard then
+ *      produces an actionable FS_ERROR if the cwd is non-empty).
+ *   4. Interactive prompt for a directory name.
+ */
+async function resolveTargetName(
+  dir: string | undefined,
+  cwd: string,
+  headless: boolean,
+): Promise<string> {
+  if (dir && dir.trim().length > 0) return dir.trim();
+  if (await isDirEffectivelyEmpty(cwd)) return ".";
+  if (headless) return ".";
+  const { dirName } = await inquirer.prompt<{ dirName: string }>([
+    {
+      type: "input",
+      name: "dirName",
+      message: "Directory name for the new project:",
+      validate: (v: string) =>
+        v && v.trim().length > 0 ? true : "Enter a non-empty directory name",
+    },
+  ]);
+  return dirName.trim();
+}
+
+export async function setupCommand(
+  dir: string | undefined,
+  opts: SetupOptions = {},
+): Promise<void> {
+  const startMs = Date.now();
+  const headless = opts.yes === true;
+  // `interactive` gates `--format json` without `--yes` (exit 2) at the
+  // beginCommand chokepoint, mirroring init.ts. banner "none": init prints its
+  // own banner on the happy path, so setup stays silent to avoid a double banner.
+  const format = beginCommand(opts, { banner: "none", interactive: !headless });
+
+  const cwd = process.cwd();
+  const targetName = await resolveTargetName(dir, cwd, headless);
+  const targetDir = resolve(cwd, targetName);
+
+  const alreadyExists = await pathExists(targetDir);
+  // Overwrite guard: an existing target with real content (anything beyond a
+  // lone `.git`) is never clobbered.
+  if (alreadyExists && !(await isDirEffectivelyEmpty(targetDir))) {
+    throw new HatchError(
+      `Target directory ${chalk.bold(targetName)} already exists and is not empty.`,
+      undefined,
+      "FS_ERROR",
+      `Pick a new or empty directory — e.g. \`hatch3r setup <new-dir>\` — or clear the existing contents first.`,
+    );
+  }
+
+  const gitDirExists = await pathExists(join(targetDir, ".git"));
+  const willCreateDir = !alreadyExists;
+  const willGitInit = !gitDirExists;
+  // Only probe gh when --remote is requested (read-only, but skipped otherwise
+  // to keep the no-flag path free of subprocess calls).
+  const ghReady = opts.remote === true ? isGhReady() : false;
+  const repoName = basename(targetDir);
+
+  // ── Dry run: print the plan, write nothing, do not run init ───────────────
+  if (opts.dryRun) {
+    const lines: string[] = [];
+    lines.push(
+      willCreateDir
+        ? `${chalk.green("+")} create directory ${chalk.bold(targetName)}`
+        : `${chalk.dim("=")} use existing empty directory ${chalk.bold(targetName)}`,
+    );
+    lines.push(
+      willGitInit
+        ? `${chalk.green("+")} run \`git init\` in ${chalk.bold(targetName)}`
+        : `${chalk.dim("=")} git repository already present — skip \`git init\``,
+    );
+    if (opts.remote === true) {
+      lines.push(
+        ghReady
+          ? `${chalk.green("+")} create GitHub remote \`${repoName}\` via \`gh repo create\``
+          : `${chalk.yellow("!")} \`--remote\` set but \`gh\` is unavailable/unauthenticated — skip remote`,
+      );
+    }
+    lines.push(`${chalk.cyan(">")} run \`hatch3r init\` in ${chalk.bold(targetName)}`);
+
+    finishCommand(format, {
+      command: "setup",
+      title: "Setup (dry run)",
+      style: "info",
+      lines,
+      json: {
+        dryRun: true,
+        targetDir,
+        createDir: willCreateDir,
+        gitInit: willGitInit,
+        remote: opts.remote === true ? { requested: true, ghReady } : { requested: false },
+        wouldRunInit: true,
+      },
+      nextSteps: ["Re-run without --dry-run to scaffold and start init."],
+      startMs,
+    });
+    return;
+  }
+
+  // ── Scaffold ──────────────────────────────────────────────────────────────
+  await mkdir(targetDir, { recursive: true });
+  if (willCreateDir) {
+    info(`Created project directory ${chalk.bold(targetName)}`);
+  } else {
+    info(`Using directory ${chalk.bold(targetName)}`);
+  }
+
+  if (willGitInit) {
+    runGit(["init"], targetDir);
+    info("Initialized empty Git repository");
+  } else {
+    info("Git repository already present — skipping `git init`");
+  }
+
+  if (opts.remote === true) {
+    if (ghReady) {
+      try {
+        runGit(["status"], targetDir); // ensure the repo is readable before gh attaches
+        execFileSync("gh", ["repo", "create", repoName, "--source", targetDir, "--private"], {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        info(`Created GitHub remote ${chalk.bold(repoName)} (private)`);
+      } catch (err) {
+        // A remote failure must not abort the local scaffold.
+        warn(
+          `Could not create the GitHub remote: ${err instanceof Error ? err.message : String(err)}. ` +
+            `Continuing with the local project; run \`gh repo create\` manually later.`,
+        );
+      }
+    } else {
+      warn(
+        `--remote was requested but the GitHub CLI (gh) is not installed or not authenticated. ` +
+          `Skipping remote creation. Install gh and run \`gh auth login\`, then \`gh repo create\` ` +
+          `from the new directory. Continuing with the local scaffold.`,
+      );
+    }
+  }
+
+  // ── Chain into init inside the new directory ──────────────────────────────
+  // init emits its own banner + outcome box / JSON envelope, so setup does not
+  // call finishCommand on the happy path (one terminal outcome, never two).
+  process.chdir(targetDir);
+  await initCommand({
+    tools: opts.tools,
+    preset: opts.preset,
+    maturity: opts.maturity,
+    yes: opts.yes,
+    quiet: opts.quiet,
+    format: opts.format,
+    verbose: opts.verbose,
+  });
+}

--- a/src/cli/program.ts
+++ b/src/cli/program.ts
@@ -5,6 +5,7 @@ import { worktreeCleanupCommand } from "./commands/worktreeCleanup.js";
 import { cleanCommand } from "./commands/clean.js";
 import { configCommand } from "./commands/config.js";
 import { initCommand } from "./commands/init.js";
+import { setupCommand } from "./commands/setup.js";
 import { syncCommand } from "./commands/sync.js";
 import { updateCommand } from "./commands/update.js";
 import { validateCommand } from "./commands/validate.js";
@@ -170,6 +171,29 @@ export function createProgram(): Command {
     .option("--facets <list>", "Comma-separated graduated-customization facets to add on top of the preset: a11y, performance, observability")
     .option("--per-package", "On a monorepo, also copy adapter output under each package (default: root-only). Capped at 25 packages, batched, and .gitignore'd")
     .action(initCommand);
+
+  program
+    .command("setup [dir]")
+    .description("Scaffold a fresh project (mkdir + git init, optional GitHub remote) then chain into `hatch3r init`. Needs only Node + git; --remote is opt-in")
+    // --remote is opt-in and degrades to a warning when `gh` is missing/unauthed
+    // — the happy path must succeed with only Node 22+ and git installed.
+    .option("--remote", "Create a private GitHub remote via `gh repo create` after git init (skipped with a warning when gh is missing or unauthenticated)")
+    // Pass-through init options (subset of `init`'s flag surface, forwarded to
+    // initCommand after the scaffold step).
+    .option("--tools <tools>", `Comma-separated tools (${TOOL_CHOICES})`)
+    .option("--preset <preset>", "Content preset forwarded to init (e.g. minimal, standard, full, web-app)")
+    .option("--maturity <tier>", "Project maturity tier forwarded to init: solo, team, scaleup, enterprise (default: solo)")
+    .option("--yes", "Skip interactive prompts (scaffold + init use smart defaults)")
+    // --format/--quiet/--dry-run/--verbose provenance: W5 flag-surface standardization.
+    .option(
+      "--format <format>",
+      "Output format for CI consumers: human (default) or json",
+      "human",
+    )
+    .option("--quiet", "Suppress stdout chrome (banner, spinner, boxes); stderr diagnostics still emit")
+    .option("--dry-run", "Preview the scaffold plan (create dir, git init, remote, then run init) without writing anything")
+    .option("--verbose", "Show detailed per-step output")
+    .action(setupCommand);
 
   program
     .command("sync")

--- a/src/cli/shared/constants.ts
+++ b/src/cli/shared/constants.ts
@@ -28,6 +28,12 @@ export const FEATURE_CHOICES: { name: string; value: keyof Features }[] = [
   { name: "MCP", value: "mcp" },
   { name: "Hooks", value: "hooks" },
   { name: "GitHub agents", value: "githubAgents" },
+  // 2.1.0 (Task D): handoffs was a live control surface (DEFAULT_FEATURES.handoffs
+  // = true, threaded into bridge-orchestration emission) but absent from the
+  // picker, so the config feature-rebuild loop silently forced it false on every
+  // run. Listed here (default checked) so it round-trips; the rebuild loop is
+  // additionally hardened to preserve unlisted features (see config.ts).
+  { name: "Handoffs", value: "handoffs" },
 ];
 
 export const MCP_CHOICES = Object.entries(AVAILABLE_MCP_SERVERS).map(([id, meta]) => ({

--- a/src/cli/shared/flowSteps.ts
+++ b/src/cli/shared/flowSteps.ts
@@ -467,16 +467,22 @@ export function maturityStep<TState extends { maturity: MaturityTier }>(
 
 // ── confidenceFloor ─────────────────────────────────────────────────
 
-export interface ConfidenceFloorStepOptions {
+export interface ConfidenceFloorStepOptions<TState extends object = object> {
   /** Prompt copy — config: "Agent assertiveness floor:". */
   message: string;
   /**
-   * First-visit default. config injects the tier-aware resolved value
-   * (`readConfidenceFloor(manifest)`): an explicit persisted floor wins, else
-   * solo/team default `any` and scaleup/enterprise default `high`. Builders
-   * never read the manifest.
+   * First-visit default. Either a fixed floor, or a resolver over the
+   * in-progress state. config passes a resolver so the seed tracks the maturity
+   * tier the user picked EARLIER in this same run (the maturity step is
+   * sequenced before this one): `readConfidenceFloor` with the in-run maturity
+   * keeps an explicit persisted floor winning, else solo/team default `any` and
+   * scaleup/enterprise default `high`. Without the resolver the seed would lag a
+   * mid-run maturity bump, and accepting a stale default could pin a floor that
+   * contradicts the newly-chosen tier. Builders never read the manifest — the
+   * caller closes over it inside the resolver (mirrors `tier2Suggested` /
+   * `defaultPreset`).
    */
-  defaultFloor: ConfidenceFloor;
+  defaultFloor: ConfidenceFloor | ((state: Partial<TState>) => ConfidenceFloor);
 }
 
 /**
@@ -487,11 +493,13 @@ export interface ConfidenceFloorStepOptions {
  * `config confidence_floor=<v>` form remains).
  */
 export function confidenceFloorStep<TState extends { confidenceFloor: ConfidenceFloor }>(
-  opts: ConfidenceFloorStepOptions,
+  opts: ConfidenceFloorStepOptions<TState>,
 ): StepFor<TState, "confidenceFloor"> {
   return {
     id: "confidenceFloor",
-    async run(_state, previous): Promise<StepResult<TState["confidenceFloor"]>> {
+    async run(state, previous): Promise<StepResult<TState["confidenceFloor"]>> {
+      const resolvedDefault =
+        typeof opts.defaultFloor === "function" ? opts.defaultFloor(state) : opts.defaultFloor;
       const answer = await inquirer.prompt<{ confidenceFloor: ConfidenceFloor | typeof BACK }>([
         {
           type: "select",
@@ -502,7 +510,7 @@ export function confidenceFloorStep<TState extends { confidenceFloor: Confidence
             { name: "medium — second-pass on any low-confidence finding", value: "medium" as ConfidenceFloor },
             { name: "high — second-pass on non-high confidence + ASK on every low-confidence finding", value: "high" as ConfidenceFloor },
           ],
-          default: previous ?? opts.defaultFloor,
+          default: previous ?? resolvedDefault,
         },
       ]);
       return isBack(answer.confidenceFloor) ? BACK : (answer.confidenceFloor as TState["confidenceFloor"]);

--- a/src/cli/shared/flowSteps.ts
+++ b/src/cli/shared/flowSteps.ts
@@ -32,7 +32,14 @@ import {
   type CatalogItem,
   type ContentIndex,
 } from "../../content/index.js";
-import type { CliToolId, Features, Platform, Tool } from "../../types.js";
+import type {
+  CliToolId,
+  ConfidenceFloor,
+  Features,
+  MaturityTier,
+  Platform,
+  Tool,
+} from "../../types.js";
 
 // Leaf casts like `answer.platform as TState["platform"]` close the
 // generic seam: the builder's constraint (`TState extends { platform:
@@ -408,6 +415,97 @@ export function mcpServersStep<TState extends { mcpServers: string[] }>(
         wslTheme: opts.wslTheme,
       });
       return result as StepResult<TState["mcpServers"]>;
+    },
+  };
+}
+
+// ── maturity ────────────────────────────────────────────────────────
+
+export interface MaturityStepOptions {
+  /** Prompt copy — init: "Project maturity (investment depth):"; config: "Maturity tier:". */
+  message: string;
+  /**
+   * First-visit default. init injects the git-inferred tier
+   * (`inferTeamSizeFromGit`-seeded); config injects the persisted
+   * `readMaturityTier(manifest)` value. Builders never read the manifest.
+   */
+  defaultMaturity: MaturityTier;
+}
+
+/**
+ * Single-select maturity-tier picker (`name: "maturity"`). The choice copy
+ * names what each tier adds on top of the universal floor (see the
+ * `MaturityTier` JSDoc in `src/types.ts`); the tier is an investment dial, not
+ * a content gate (Decision 16). Used by both the init single-repo machine (the
+ * 4th of ≤6 interactive prompts; Decision 25 raised the ceiling 5→6 to admit
+ * it) and the config machine.
+ */
+export function maturityStep<TState extends { maturity: MaturityTier }>(
+  opts: MaturityStepOptions,
+): StepFor<TState, "maturity"> {
+  return {
+    id: "maturity",
+    async run(_state, previous): Promise<StepResult<TState["maturity"]>> {
+      const answer = await inquirer.prompt<{ maturity: MaturityTier | typeof BACK }>([
+        {
+          type: "select",
+          name: "maturity",
+          message: opts.message,
+          choices: [
+            { name: "solo — individual / hobby; universal floor, warn-only gates", value: "solo" as MaturityTier },
+            { name: "team — shared repo; + duplication/design discipline, strict gates", value: "team" as MaturityTier },
+            { name: "scaleup — multi-team; + SLOs, tracing, performance budgets", value: "scaleup" as MaturityTier },
+            { name: "enterprise — regulated; + mutation/contract testing, AI evals, FinOps", value: "enterprise" as MaturityTier },
+          ],
+          default: previous ?? opts.defaultMaturity,
+        },
+      ]);
+      return isBack(answer.maturity) ? BACK : (answer.maturity as TState["maturity"]);
+    },
+  };
+}
+
+// ── confidenceFloor ─────────────────────────────────────────────────
+
+export interface ConfidenceFloorStepOptions {
+  /** Prompt copy — config: "Agent assertiveness floor:". */
+  message: string;
+  /**
+   * First-visit default. config injects the tier-aware resolved value
+   * (`readConfidenceFloor(manifest)`): an explicit persisted floor wins, else
+   * solo/team default `any` and scaleup/enterprise default `high`. Builders
+   * never read the manifest.
+   */
+  defaultFloor: ConfidenceFloor;
+}
+
+/**
+ * Single-select agent-assertiveness floor picker (`name: "confidenceFloor"`).
+ * Choice copy mirrors the `ConfidenceFloor` JSDoc in `src/types.ts`. config-only
+ * — init keeps its interactive flow at ≤6 prompts (maturity is the only dial it
+ * prompts for), so confidence_floor has no init prompt (the scalar
+ * `config confidence_floor=<v>` form remains).
+ */
+export function confidenceFloorStep<TState extends { confidenceFloor: ConfidenceFloor }>(
+  opts: ConfidenceFloorStepOptions,
+): StepFor<TState, "confidenceFloor"> {
+  return {
+    id: "confidenceFloor",
+    async run(_state, previous): Promise<StepResult<TState["confidenceFloor"]>> {
+      const answer = await inquirer.prompt<{ confidenceFloor: ConfidenceFloor | typeof BACK }>([
+        {
+          type: "select",
+          name: "confidenceFloor",
+          message: opts.message,
+          choices: [
+            { name: "any — second-pass only on a low-confidence reviewer finding", value: "any" as ConfidenceFloor },
+            { name: "medium — second-pass on any low-confidence finding", value: "medium" as ConfidenceFloor },
+            { name: "high — second-pass on non-high confidence + ASK on every low-confidence finding", value: "high" as ConfidenceFloor },
+          ],
+          default: previous ?? opts.defaultFloor,
+        },
+      ]);
+      return isBack(answer.confidenceFloor) ? BACK : (answer.confidenceFloor as TState["confidenceFloor"]);
     },
   };
 }

--- a/website/docs/reference/commands/cli-commands.md
+++ b/website/docs/reference/commands/cli-commands.md
@@ -52,13 +52,49 @@ The interactive flow asks (default branch, project type, and team size are infer
 1. **Platform** -- GitHub, Azure DevOps, or GitLab (auto-detected from git remote)
 2. **Repo identity** -- owner/org and repo name (auto-filled from the remote where possible)
 3. **Content profile** -- Minimal, Standard (recommended), Full, or Custom
-4. **Custom content items** -- only when Custom is selected at step 3
-5. **Tools** -- select from the 3 supported adapters (Claude Code, Cursor, GitHub Copilot)
-6. **CLI tools** -- tier-grouped picker (tier-1 + trigger-matched tier-2 pre-checked; enter-through equals the `--yes` smart default). There is no MCP prompt — opt in with `--mcp` or `npx hatch3r mcp setup` later
+4. **Maturity tier** -- solo, team, scaleup, or enterprise (seeded at the git-inferred default); `--maturity <tier>` skips this prompt. The tier is an investment-depth dial, not a content gate -- every tier installs the full corpus (see [Maturity Tiers](../../guides/maturity-tiers))
+5. **Custom content items** -- only when Custom is selected at step 3
+6. **Tools** -- select from the 3 supported adapters (Claude Code, Cursor, GitHub Copilot)
+7. **CLI tools** -- tier-grouped picker (tier-1 + trigger-matched tier-2 pre-checked; enter-through equals the `--yes` smart default). There is no MCP prompt — opt in with `--mcp` or `npx hatch3r mcp setup` later
+
+The common (non-custom) path is 6 prompts; the custom-content multi-select adds a 7th only when Custom is chosen at step 3.
 
 Only the content matching your profile and context is generated into your adapter outputs (canonical content is read from the bundled npm package, not copied into your repo). Use `hatch3r config` to add or remove items later.
 
 With `--yes`, init auto-detects greenfield/brownfield, defaults to solo + standard preset, selects tier-1 + triggered tier-2 CLI tools, and skips all prompts.
+
+## hatch3r setup
+
+Added in 2.1.0. Scaffolds a fresh project directory and then chains into the `hatch3r init` prompts inside it. The happy path needs only Node 22+ and `git`.
+
+```bash
+npx hatch3r setup my-app
+npx hatch3r setup my-app --remote
+npx hatch3r setup demo --yes --tools claude
+npx hatch3r setup my-app --dry-run    # preview the scaffold without writing
+```
+
+**Flags:**
+
+| Flag | Values | Default | Description |
+|------|--------|---------|-------------|
+| `--remote` | — | off | Create a private GitHub remote via `gh repo create` after `git init`. Acts only when `gh` is installed and authenticated (`gh auth status` exits 0); otherwise it prints a warning and continues the local scaffold |
+| `--tools` | comma-separated tool names | auto-detected | Forwarded to `init` — which coding tools to configure (Claude Code, Cursor, Copilot) |
+| `--preset` | `minimal`, `standard`, `full`, or any `init` preset value | `standard` | Forwarded to `init` — content profile preset |
+| `--maturity` | `solo`, `team`, `scaleup`, `enterprise` | git-inferred | Forwarded to `init` — investment-depth tier; supplying it skips the maturity prompt |
+| `--yes` | — | off | Forwarded to `init` — skip all prompts (headless mode) |
+| `--format <human\|json>` | `human`, `json` | `human` | Forwarded to `init`. `--format json` without `--yes` is an exit-2 usage error |
+| `--quiet` | — | off | Forwarded to `init` — suppress stdout chrome |
+| `--dry-run` | — | off | Preview the scaffold plan (directory, `git init`, remote, then init) and write nothing; `init` is not run |
+| `--verbose` | — | off | Forwarded to `init` — verbose per-step output |
+
+What it does, in order:
+
+1. Resolves the target directory from the positional `[dir]` argument; when omitted it uses the current directory if empty, otherwise prompts for a directory name. An existing target with content beyond a lone `.git` is refused with an actionable `FS_ERROR` (exit 74)
+2. Creates the directory (skipped when it already exists empty)
+3. Runs `git init` — idempotent, skipped when a `.git` is already present
+4. With `--remote`, creates the private GitHub remote (warns and continues when `gh` is missing/unauthenticated, or if `gh repo create` fails)
+5. Changes into the new directory and runs the `hatch3r init` prompts (see above); `init` emits the single terminal outcome box / JSON envelope
 
 ## hatch3r config
 


### PR DESCRIPTION
## Summary

Release **2.1.0** — a new `hatch3r setup` command, fixes for the `/` slash-command picker descriptions and the `handoffs` feature, an always-ask maturity-tier prompt in `init`, and a scoped audit of the init/config input surface.

No breaking CLI changes; manifest schema unchanged (schemaVersion 3).

## What's in it

### Added
- **`hatch3r setup [dir]`** — scaffold a fresh project (mkdir + idempotent `git init`, opt-in `--remote` via `gh`) then chain into the `init` prompts. Standard `--format`/`--quiet`/`--dry-run`/`--verbose` matrix. (CLI commands 19 → 20.)
- **Maturity-tier prompt in `init`** — every interactive run now asks for the project maturity tier (the 4th of ≤6 prompts; `--maturity` skips it), seeded at the git-inferred default. Matching maturity step added to `config`.
- **`confidence_floor` step in `config`** — settable interactively (tier-aware default), not just via the `config confidence_floor=` scalar.
- **Inferred-default feedback in `init`** — prints the default branch + maturity it inferred, so silent defaults are visible.
- **`handoffs` in the `config` feature picker.**

### Fixed
- **Slash-command picker descriptions** — command files (Claude Code, Cursor, Copilot) and Claude skill files now emit byte-0 `description:` frontmatter, so the `/` picker shows each artifact's real description instead of the `HATCH3R:BEGIN` managed-block marker. Covers the synthetic `hatch3r-agent-team` launcher.
- **`handoffs` silently disabled on `config` re-run** — it was missing from the feature picker, so the rebuild forced it off. The rebuild now preserves any feature not shown in the picker (fixes `handoffs` and prevents the same class of silent drop for future features).

## Input-surface audit (init/config)

A scoped audit of every init/config prompt, flag, and manifest field surfaced these gaps:

| Gap | Severity | Disposition |
|-----|----------|-------------|
| `handoffs` dropped on re-config | Critical | **Fixed** |
| `confidence_floor` no interactive surface | High | **Fixed** |
| `maturity` never prompted | High | **Fixed** (always-ask) |
| `defaultBranch` / `teamSize` inferred silently | Medium | **Fixed** (feedback lines) |
| `features.mcp` desyncs from server list across config cycles | High | Deferred (follow-up) |
| `worktree.enabled` init auto-enables vs config prompts | Medium | Deferred |

## Governance

The always-ask maturity change raised the interactive-init prompt ceiling 5 → 6. That is codified in the private `hatch3r-governance` repo as a new CONSTITUTION §6 Decision 25 (the prior code citation to "Decision 25" had been dangling — it now resolves), alongside the D03 test-file count bump and an SA-per-finding-ratio citation fix (§6 Decision 25 → Decision 18). Committed separately to the governance overlay.

## Verification

- `npm test` — **236 test files green** (full suite, run in chunks; only pre-existing skips).
- `npm run validate` — **0 errors** (decision-id-consistency 32 rows, adapter-parity 67×3, anti-slop 0 hits, content-duplication under ceiling).
- `npx tsc --noEmit`, `npm run lint`, `npm run build` — clean.
- `npm run inventory` + `inventory:check-docs` — 20 CLI commands, version 2.1.0, 0 drift.
- Smoke: `hatch3r setup --help` registers with the full flag matrix; generated command/skill files start with `---` frontmatter (not the marker).

## Known follow-ups (not in this PR)
- Workspace-mode `init` does not yet prompt maturity (single-repo does).
- `features.mcp` ↔ server-list desync across `config` cycles (High).
- `worktree.enabled` init/config prompt asymmetry (Medium).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CLI onboarding (`setup`, init/config prompts), manifest feature persistence, and generated adapter file shapes across all three tools—users re-running `sync` will get new frontmatter layouts, but behavior is covered by extensive new/updated tests.
> 
> **Overview**
> **2.1.0** bumps package/plugin versions and documents the release in `CHANGELOG.md`.
> 
> **New `hatch3r setup [dir]`** scaffolds a project (mkdir, idempotent `git init`, optional `--remote` via `gh`), then `chdir`s and runs `init` with forwarded flags and the standard `--format` / `--dry-run` surface.
> 
> **Adapter generation** switches commands (and Claude skills) from raw managed blocks to **byte-0 YAML frontmatter** (`name`, double-quoted `description`, and `argument-hint` where present) via `processCommandsWithFm` / quoted skill descriptions, so `/` pickers show real descriptions instead of `HATCH3R:BEGIN`. Claude’s cache-breakpoint rewrap preserves that prefix; the synthetic `hatch3r-agent-team` command gets the same treatment.
> 
> **Interactive `init`** adds a **maturity** prompt (≤6 prompts; `--maturity` skips) and prints inferred default branch + maturity. **`config`** adds maturity and **confidence_floor** steps, lists **handoffs** in the feature picker, and **`rebuildFeaturesFromSelection`** so features not shown in the picker keep their prior manifest values (fixing silent `handoffs` disable on re-run).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83bae31f21fab8b1f159025bc3ec60799aa338e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->