### PR TITLE
fix(test): drop per-test 30s timeouts that clamp the win32 heavy-fs headroom

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,17 +9,18 @@ updates:
         dependency-type: "production"
       development:
         dependency-type: "development"
-  # Cycle 12 L D4-SA4.2-05 (D4): TypeScript 7.0 went GA 2026-07-08 (Go-native
-  # compiler; Microsoft states identical type-checking semantics). The manifest
-  # pins `typescript: ^6.0.2`, so a 7.x bump rewrites the major range — a
-  # deliberate migration decision, NOT routine dev-group drift. Migration
-  # surface is `npx tsc --noEmit` semantics + @types compatibility only: tsc is
-  # typecheck-only here (tsup/esbuild transpiles), so there is no runtime/build
-  # blast radius. No `ignore` rule is set — this records the tracked owner, it
-  # does not pre-empt the decision. Maintainer action: when a `typescript` 7.x
-  # major appears (verify whether the weekly dev-group PR carries typescript to
-  # 7.0.x vs a 6.0.x patch), run the `tsc --noEmit` + @types assessment before
-  # merge; do not auto-merge as routine dev-group drift. Adopt/defer pending.
+    # Cycle 12 L D4-SA4.2-05 (D4) resolution, 2026-07-13: TypeScript 7.0 went GA
+    # 2026-07-08; the weekly dev-group PR carried typescript 6.0.2 -> 7.0.2 and
+    # failed `npm ci` with ERESOLVE on every CI leg — typescript-eslint@8.63.0
+    # peer-rejects typescript 7.x, so adoption is mechanically blocked before
+    # the planned `tsc --noEmit` + @types assessment can even run. Decision:
+    # DEFER via the ignore rule below (majors only; 6.x minors/patches still
+    # flow). Revisit trigger: typescript-eslint publishes a release whose peer
+    # range admits typescript 7.x — then delete this ignore rule and run the
+    # assessment recorded in the D4-SA4.2-05 finding before merging the bump.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   # Cycle 12 H D4-SA4.2-02 (D4): the website/ Docusaurus site ships its own
   # package.json + package-lock.json (committed 2026-03-02) that the root "/"
   # npm entry above does not cover — dependabot `directory` scoping is exact,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,18 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     # Windows runners are I/O-slow and variable: the full suite (npm ci + build
-    # + ~5866 tests, no coverage) finishes well under the limit on a fast
-    # windows-latest box, but slow-runner variance is wide. The suite grew
-    # ~4500 -> 5866 and slow node 22/24/26 runs overran the prior 25-min ceiling
-    # (all three cancelled at ~25m on release/2.0.0-final) while a fast node 26
-    # run finished in <10 min on the SAME commit with every test passing. Give
-    # Windows 35-min headroom; keep the tight 15-min hang-guard for the fast OSes.
-    timeout-minutes: ${{ matrix.os == 'windows-latest' && 35 || 15 }}
+    # + ~7000 tests, no coverage) finishes well under the limit on a fast
+    # windows-latest box, but slow-runner variance is wide. History: the suite
+    # grew ~4500 -> 5866 and slow runs overran the then-25-min ceiling (all
+    # three Windows legs cancelled at ~25m on release/2.0.0-final) -> bumped to
+    # 35; it then grew to ~6994 and on 2026-07-13 two Windows legs on unrelated
+    # branches hit the 35-min cap (runs 29246026136 attempt 2 at 35m16s,
+    # 29255254229 attempt 1 at 35m11s) while sibling legs on the same commits
+    # passed at ~32m — nominal duration had eaten the margin, and the heavy-fs
+    # win32 testTimeout (120s) legitimately extends the worst case. 50 min
+    # keeps a hang-tripwire ~1.5x the nominal slow-runner duration; keep the
+    # tight 15-min hang-guard for the fast OSes.
+    timeout-minutes: ${{ matrix.os == 'windows-latest' && 50 || 15 }}
     strategy:
       fail-fast: false
       matrix:

--- a/src/__tests__/cli/status.test.ts
+++ b/src/__tests__/cli/status.test.ts
@@ -585,10 +585,13 @@ describe("status command", () => {
   // is in vitest.config.ts: status.test.ts + verify.test.ts run in a separate
   // "heavy-fs" project at a later sequence.groupOrder, so they execute ALONE
   // after the parallel "main" group drains — no concurrent FS churn. The prior
-  // per-test `retry` is gone (the contention it papered over no longer occurs);
-  // `timeout` stays as a margin for the genuinely-large FS batch. Assertions
+  // per-test `retry` is gone (the contention it papered over no longer occurs).
+  // No suite-level `timeout` here: a per-suite value overrides the heavy-fs
+  // project's platform-aware testTimeout (120s on win32, 30s elsewhere), so a
+  // flat 30s override silently clamped windows-latest back to 30s — the exact
+  // spurious-timeout class the 120s headroom exists to absorb. Assertions
   // (0 false orphans / in-sync) are unchanged.
-  describe("monorepo per-package drift (D14-1)", { timeout: 30_000 }, () => {
+  describe("monorepo per-package drift (D14-1)", () => {
     it("reports a 2-package monorepo in-sync with 0 false orphans", async () => {
       // Two-package workspace fixture. The package directories do not need to
       // pre-exist — sync's safeWriteFile creates `<package>/...` parents

--- a/src/__tests__/cli/verify.test.ts
+++ b/src/__tests__/cli/verify.test.ts
@@ -359,10 +359,13 @@ describe("verify command", () => {
   // is in vitest.config.ts: status.test.ts + verify.test.ts run in a separate
   // "heavy-fs" project at a later sequence.groupOrder, so they execute ALONE
   // after the parallel "main" group drains — no concurrent FS churn. The prior
-  // per-test `retry` is gone (the contention it papered over no longer occurs);
-  // `timeout` stays as a margin for the genuinely-large FS batch. Assertions
+  // per-test `retry` is gone (the contention it papered over no longer occurs).
+  // No per-test `timeout` here: a per-test value overrides the heavy-fs
+  // project's platform-aware testTimeout (120s on win32, 30s elsewhere), so a
+  // flat 30s override silently clamped windows-latest back to 30s — the exact
+  // spurious-timeout class the 120s headroom exists to absorb. Assertions
   // (verify PASS / 0 false orphans) are unchanged.
-  it("verifies a 2-package monorepo as PASS with no false-orphan drift (D14-1)", { timeout: 30_000 }, async () => {
+  it("verifies a 2-package monorepo as PASS with no false-orphan drift (D14-1)", async () => {
     await createTestProject(tempDir, {
       tools: ["cursor", "claude"],
       packages: [


### PR DESCRIPTION
## Summary

Two CI-red remediations from the 2026-07-13 red runs:

### 1. Windows heavy-fs flake — root cause removed
The heavy-fs vitest project sets a platform-aware `testTimeout` (120s on win32, 30s elsewhere) because windows-latest runners are I/O-slow. The two D14-1 monorepo tests carried their own `{ timeout: 30_000 }` overrides — `status.test.ts:591` (describe-level) and `verify.test.ts:365` (test-level) — and per-test overrides win over the project value, silently clamping exactly the heaviest tests back to 30s on Windows. On Linux/macOS the override equals the project default (no-op); its only effect was defeating the Windows headroom.

Observed failures: `Test timed out in 30000ms` on `build (24, windows-latest)` of PR #125's CI run (status.test.ts) and on both Windows legs of the harden-runner dependabot run (verify.test.ts); all other matrix legs passed.

Sweep: all 16 `HEAVY_FS_TEST_FILES` checked for the pattern (object-form, numeric third-arg, `vi.setConfig`) — these two sites are the complete set.

### 2. Dependabot dev-group ERESOLVE — TS 7 major deferred
The weekly dev-group PR bumped `typescript` 6.0.2 → 7.0.2; `typescript-eslint@8.63.0` peer-rejects TS 7, so `npm ci` fails with ERESOLVE on every leg. The D4-SA4.2-05 comment deliberately deferred this decision until the 7.x bump arrived — it arrived and is mechanically blocked, so the decision resolves to defer: ignore rule for typescript semver-majors (6.x minors/patches still flow), comment rewritten to record the resolution + revisit trigger.

## Verification
- `npx vitest run src/__tests__/cli/status.test.ts src/__tests__/cli/verify.test.ts` exit 0 — 41/41 passing
- `npx tsc --noEmit` exit 0
- `npx eslint` on both changed test files exit 0

## Post-merge follow-ups
- Comment `@dependabot recreate` on the dev-group PR (branch `dependabot/npm_and_yarn/development-e36ddb22d7`) so it regenerates without the TS 7 bump — dependabot reads config from the default branch, so this only works after merge.
- The harden-runner PR's failed Windows legs were re-run (flake class above); if green it can merge as-is and picks up this fix on its next weekly rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI timeouts, dependabot policy, and test-only timeout overrides—no production CLI or runtime behavior.
> 
> **Overview**
> Addresses **Windows CI reds** from two causes: per-test `{ timeout: 30_000 }` on the heaviest D14-1 monorepo tests in `status.test.ts` and `verify.test.ts` was overriding the **heavy-fs** vitest project’s **120s** `testTimeout` on win32, so those tests could still fail at 30s despite the platform headroom. Those overrides are removed so the project config applies.
> 
> The **build** job’s **windows-latest** `timeout-minutes` is raised **35 → 50** as the suite grew (~7k tests) and slow runners were hitting the cap while sibling legs passed.
> 
> **Dependabot** now **ignores semver-major `typescript` bumps** after the dev-group PR failed `npm ci` with **ERESOLVE** (`typescript-eslint` peer-rejects TS 7); comments record defer until eslint peers admit TS 7.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e5be58d87ba7d832d471499e898a2588a3ac2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->