### PR TITLE
fix(cli): sweep the safeWriteFile silent-skip class off machine-local state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to hatch3r are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- **Silent no-op writes on existing machine-local state (safeWriteFile skip-branch sweep)** — `safeWriteFile` on an existing target that is neither hatch3r-named nor written with `force` skips non-destructively; four callers that own the target relied on it anyway and silently stopped writing once the file existed. Swept and fixed: (1) failure-log rotation (`.hatch3r/.failure-log.jsonl`) never rotated and dropped the new entry while reporting it written; (2) circuit-breaker state (`.hatch3r/.breaker-state.jsonl`) never persisted past the first `sync`/`update` — and even the hydrated state was dead on arrival because the on-disk map is keyed by serviceId (`adapter:<tool>`) while the adapter loop looks up bare tool names, so failures re-counted from zero on every run; both writes now pass `{ force: true, backup: false }` (hatch3r-owned, gitignored, regenerable state; no `.bak` litter) and hydration re-keys into the loop's tool vocabulary; (3) `init --per-package` `.gitignore` registration silently skipped any repo with a pre-existing `.gitignore` (generated per-package copies then got committed by `git add .`) — now appended via the crash-safe atomic writer, matching `ensureGitignoreEntry`; (4) the worktree-include writes in `update` (reconciliation + the worktree-config-init migration checkpoint) and `config` missed `appendIfNoBlock`/`managedContent`, so a `.worktreeinclude` with stripped or absent markers was skipped forever — all three now splice the managed block back in, matching sync's D11-H-3 contract.
+- **Spurious "managed block markers missing" warning on every re-sync of raw JSON outputs** — the claude adapter emits `.claude/settings.json`, `.claude/hooks/agent-tool-policies.json`, `.claude/hooks/hatch3r-hooks.json`, and `.mcp.json` without managed blocks by design (JSON has no comment syntax), so a fresh `init` → `sync` round-trip warned "Skipped …: managed block markers (HATCH3R:BEGIN/END) missing" for byte-identical files. The unmanaged skip branch now applies the same skip-if-unchanged guard as every sibling branch (identical bytes report `unchanged`, no warning; `sync --dry-run` predicts the same), and the residual genuine-difference warning names the real condition and recovery (`hatch3r sync --force` with a `.bak` backup, or delete + re-run) instead of impossible marker restoration. Overwrite-on-sync stays off for these files — they are user-editable (permissions, MCP servers), and force-overwriting would destroy those edits.
+
 ## [2.7.1] - 2026-07-16
 
 ### Headline

--- a/src/__tests__/cli/config.test.ts
+++ b/src/__tests__/cli/config.test.ts
@@ -150,7 +150,16 @@ vi.mock("../../merge/safeWrite.js", async () => {
   const { writeFile, mkdir } = await import("node:fs/promises");
   const { dirname } = await import("node:path");
   return {
-    safeWriteFile: vi.fn(),
+    // Silent-writes sweep (release/2.7.1): configCommand now reads the
+    // MergeResult that safeWriteFile resolves (`wtResult.warning` on the
+    // worktree-include write, config.ts) — a bare `vi.fn()` resolves
+    // undefined and the `.warning` read throws. Honor the real contract
+    // with a minimal `{ path, action }` MergeResult (src/types.ts). The
+    // implementation is passed INTO vi.fn() (not set via mockResolvedValue)
+    // so the afterEach `vi.restoreAllMocks()` restores THIS implementation
+    // instead of wiping it after the first test — same style as the
+    // functional atomicWriteFile mock below.
+    safeWriteFile: vi.fn(async (filePath: string) => ({ path: filePath, action: "updated" as const })),
     // F1.2-H1 (Cycle 10): configCommand wraps its body in an outer manifest
     // lock; mock returns a no-op release so tests do not need HATCH3R_LOCK=1.
     acquireWriteLock: vi.fn().mockResolvedValue(async () => {}),

--- a/src/__tests__/cli/init.test.ts
+++ b/src/__tests__/cli/init.test.ts
@@ -3720,6 +3720,35 @@ describe("init per-package emission gate (D14-SA14.2-H1)", () => {
     }
   });
 
+  // Silent-writes sweep (release/2.7.1): `.gitignore` is not a hatch3r-managed
+  // filename, so the per-package entry registration previously routed through
+  // safeWriteFile's skip branch whenever the repo already HAD a `.gitignore` —
+  // the entries were silently never appended and `git add .` committed every
+  // generated per-package copy. The append now writes through atomicWriteFile
+  // (the ensureGitignoreEntry #240 convention); the composed content is
+  // append-only over the existing bytes.
+  it("appends per-package entries to a PRE-EXISTING .gitignore and preserves its content", async () => {
+    await makeMonorepo(tempDir, ["a", "b"]);
+    await writeFile(join(tempDir, ".gitignore"), "node_modules/\ndist/\n", "utf-8");
+
+    await initCommand({ yes: true, tools: "cursor", perPackage: true });
+
+    const manifest = JSON.parse(await readFile(join(tempDir, HATCH3R_DIR, "hatch.json"), "utf-8"));
+    const cursorManaged = manifest.managedFilesByAdapter.cursor as string[];
+    const pkgPaths = cursorManaged.filter((p) => p.startsWith("packages/"));
+    expect(pkgPaths.length).toBeGreaterThan(0);
+
+    const gitignore = await readFile(join(tempDir, ".gitignore"), "utf-8");
+    const ignored = new Set(gitignore.split("\n").map((l) => l.trim()));
+    // Pre-fix: the skip branch dropped every per-package entry here.
+    for (const p of pkgPaths) {
+      expect(ignored.has(`/${p}`)).toBe(true);
+    }
+    // The user's original entries survive (append-only composition).
+    expect(ignored.has("node_modules/")).toBe(true);
+    expect(ignored.has("dist/")).toBe(true);
+  });
+
   // D14-6: per-package copying fights the load model of claude (ancestor-loads
   // root CLAUDE.md → double-load) and copilot (root-only
   // .github/copilot-instructions.md → never read). Even WITH --per-package they

--- a/src/__tests__/cli/lifecycle.test.ts
+++ b/src/__tests__/cli/lifecycle.test.ts
@@ -45,6 +45,17 @@ import { HATCH3R_VERSION } from "../../version.js";
  * produce two checkpoints with distinct timestamps by design (so `--resume`
  * has an accurate "when did the last phase complete" record); the adapter
  * outputs they protect remain byte-identical.
+ *
+ * Silent-writes sweep (release/2.7.1): `.hatch3r/.breaker-state.jsonl` is
+ * excluded for the same reason. `sync` now re-persists the circuit-breaker
+ * ledger on EVERY run (`force: true` — pre-sweep, the unmanaged-filename
+ * skip silently froze the file after first creation, so breaker state never
+ * survived past the first run; see sync.ts D8-M4), and each JSONL entry
+ * carries a load-bearing `persistedAt` wall-clock timestamp (24h TTL expiry
+ * in `parseBreakerStateLog`, src/pipeline/circuitBreaker.ts). Two idempotent
+ * syncs therefore produce two distinct ledger byte-states by design —
+ * machine-local, gitignored operational state, not deterministic generated
+ * output.
  */
 async function snapshotProject(root: string): Promise<Map<string, string>> {
   const snapshot = new Map<string, string>();
@@ -65,6 +76,10 @@ async function snapshotProject(root: string): Promise<Map<string, string>> {
       }
       if (!entry.isFile()) continue;
       if (/\.tmp\.[0-9a-f]{8}$/.test(entry.name)) continue;
+      // Skip the circuit-breaker operational ledger — re-persisted with a
+      // fresh `persistedAt` timestamp on every sync since the silent-writes
+      // sweep (release/2.7.1); see JSDoc above.
+      if (entryRel === ".hatch3r/.breaker-state.jsonl") continue;
       const buf = await readFile(full);
       const hash = createHash("sha256").update(buf).digest("hex");
       snapshot.set(relative(root, full), hash);
@@ -232,7 +247,8 @@ describe("init -> sync -> update lifecycle", { timeout: 60_000, sequential: true
     // sync. The first sync after `init` is the only run that diffs its
     // per-adapter output against the manifest history `init` wrote, sweeps a
     // cold orphan set, and first-creates non-deterministic operational ledgers
-    // (`.hatch3r/.breaker-state.jsonl`, the `.sync-workspace/` checkpoint).
+    // (`.hatch3r/.breaker-state.jsonl`, the `.sync-workspace/` checkpoint —
+    // both excluded from `snapshotProject`; see its JSDoc).
     // Snapshotting after the FIRST sync (the prior shape of this test) compared
     // a post-init-cold state against a warm one, leaving a window where the two
     // snapshots could legitimately differ on first-run-only side effects. With

--- a/src/__tests__/cli/sync.test.ts
+++ b/src/__tests__/cli/sync.test.ts
@@ -280,17 +280,25 @@ describe("sync command", () => {
     expect(mcpJson).toBeNull();
   });
 
-  it("should report 'skipped' for unchanged non-managed files on re-sync", async () => {
+  // Silent-writes sweep (release/2.7.1): byte-identical non-managed files
+  // (raw JSON outputs like .cursor/environment.json) report "unchanged" on
+  // re-sync — previously they reported "skipped" plus a spurious "managed
+  // block markers missing" warning on every run after a fresh init/sync.
+  it("should report 'unchanged' (not 'skipped') for byte-identical non-managed files on re-sync", async () => {
     await createTestProject(tempDir);
 
     const { syncCommand } = await import("../../cli/commands/sync.js");
     await syncCommand();
 
     consoleSpy.mockClear();
+    consoleErrorSpy.mockClear();
     await syncCommand();
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
-    expect(output).toContain("skipped");
+    expect(output).toContain("unchanged");
+    // No spurious marker warning for hatch3r's own marker-less JSON outputs.
+    const stderr = consoleErrorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(stderr).not.toContain("managed block markers");
   });
 
   it("should report 'skipped' when a non-managed file has changed on disk", async () => {
@@ -303,10 +311,17 @@ describe("sync command", () => {
     await writeFile(envJsonPath, '{"changed": true}');
 
     consoleSpy.mockClear();
+    consoleErrorSpy.mockClear();
     await syncCommand();
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(output).toContain("skipped");
+    // Silent-writes sweep (release/2.7.1): the skip warning names the real
+    // condition + recovery, not the impossible marker-restoration guidance
+    // (JSON outputs carry no HATCH3R:BEGIN/END markers by design).
+    const stderr = consoleErrorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(stderr).toContain("hatch3r sync --force");
+    expect(stderr).not.toContain("restore the markers");
   });
 
   it("should exit with error when adapter generation fails (invalid tool)", async () => {
@@ -417,6 +432,84 @@ describe("sync command", () => {
       // The whole point: 1, not 2. A regression to the double-count makes both 2.
       expect(cursorBreaker?.consecutiveFailures).toBe(1);
       expect(cursorBreaker?.totalFailures).toBe(1);
+    });
+
+    // Silent-writes sweep (release/2.7.1): `.breaker-state.jsonl` is not a
+    // hatch3r-managed filename, so once the file existed the un-forced
+    // safeWriteFile silently skipped every later persist — the second run's
+    // state never reached disk and a recurring transient failure was never
+    // recognised as already-counted. The persist now passes
+    // `{ force: true, backup: false }`.
+    it("persists breaker state across a second failing sync (file reflects run 2, not run 1)", async () => {
+      await createTestProject(tempDir, { tools: ["cursor"] });
+
+      const adapterTimeoutMod = await import("../../pipeline/adapterTimeout.js");
+      const spy = vi.spyOn(adapterTimeoutMod, "generateWithTimeout").mockResolvedValue({
+        tool: "cursor",
+        completed: false,
+        elapsedMs: 10,
+        error: 'Adapter "cursor" timed out after 180s and was skipped.',
+        warnings: [],
+      });
+
+      const { syncCommand } = await import("../../cli/commands/sync.js");
+      // Run 1 creates `.breaker-state.jsonl` (totalFailures 1). Run 2 hydrates
+      // it, records a second failure, and must OVERWRITE the existing file.
+      await expect(syncCommand()).rejects.toBeInstanceOf(HatchError);
+      await expect(syncCommand()).rejects.toBeInstanceOf(HatchError);
+      spy.mockRestore();
+
+      const { hydrateBreakersFromLog, BREAKER_STATE_FILE } = await import(
+        "../../pipeline/circuitBreaker.js"
+      );
+      const breakerRaw = await readFile(join(tempDir, HATCH3R_DIR, BREAKER_STATE_FILE), "utf-8");
+      const breakers = hydrateBreakersFromLog(breakerRaw);
+      const cursorBreaker = breakers.get("adapter:cursor");
+      expect(cursorBreaker).toBeDefined();
+      // Pre-fix the file still carried run 1's state (totalFailures 1).
+      expect(cursorBreaker?.totalFailures).toBe(2);
+      expect(cursorBreaker?.consecutiveFailures).toBe(2);
+      // No `.bak` litter next to machine-local regenerable state.
+      const bakExists = await readFile(
+        join(tempDir, HATCH3R_DIR, `${BREAKER_STATE_FILE}.bak`),
+        "utf-8",
+      ).then(() => true).catch(() => false);
+      expect(bakExists).toBe(false);
+    });
+  });
+
+  // Silent-writes sweep (release/2.7.1): the claude adapter emits raw JSON
+  // outputs without managed blocks by design (JSON has no comment syntax) —
+  // .claude/settings.json, .claude/hooks/agent-tool-policies.json,
+  // .claude/hooks/hatch3r-hooks.json. A fresh sync creates them; the next
+  // sync regenerates byte-identical content and previously reported
+  // "Skipped …: managed block markers missing" for each — misleading marker
+  // guidance for files that can never carry markers. They now report
+  // "unchanged" with no warning.
+  describe("claude raw-JSON outputs: sync round-trip produces no skip warning", () => {
+    it("second sync reports the JSON outputs unchanged and emits no marker warning", async () => {
+      await createTestProject(tempDir, { tools: ["claude"] });
+
+      const { syncCommand } = await import("../../cli/commands/sync.js");
+      await syncCommand();
+      // Sanity: the first sync created the raw JSON outputs.
+      const settings = await readFile(join(tempDir, ".claude", "settings.json"), "utf-8");
+      expect(settings).not.toContain("HATCH3R:BEGIN");
+
+      consoleSpy.mockClear();
+      consoleErrorSpy.mockClear();
+      await syncCommand();
+
+      // Note: safeWriteFile receives the absolute path, so the pre-fix warning
+      // read "Skipped <abs>/.claude/settings.json: managed block markers
+      // missing" — match on the path tail, not the literal prefix.
+      const stderr = consoleErrorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(stderr).not.toMatch(/Skipped .*settings\.json/);
+      expect(stderr).not.toMatch(/Skipped .*agent-tool-policies\.json/);
+      expect(stderr).not.toContain("managed block markers");
+
+      const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+      expect(output).toContain("unchanged");
     });
   });
 

--- a/src/__tests__/cli/update.test.ts
+++ b/src/__tests__/cli/update.test.ts
@@ -599,6 +599,30 @@ describe("update command", () => {
       ].join("\n");
       expect(output).toContain("would be generated");
     });
+
+    // Silent-writes sweep (release/2.7.1): the checkpoint's live write passed
+    // `appendIfNoBlock` WITHOUT `managedContent`, so the option was dead —
+    // over an existing user `.worktreeinclude` the write silently returned
+    // "skipped" and the managed block was never spliced in. The write now
+    // passes the managed body, so the user file gains the block with the
+    // user's content preserved below it.
+    it("splices the managed block into an existing marker-less .worktreeinclude on the live checkpoint path", async () => {
+      await createTestProject(tempDir, { worktree: undefined });
+      const manifestPath = join(tempDir, HATCH3R_DIR, "hatch.json");
+      const raw = JSON.parse(await readFile(manifestPath, "utf-8"));
+      delete raw.worktree;
+      await writeFile(manifestPath, JSON.stringify(raw, null, 2));
+      // A user-authored include file with no HATCH3R markers.
+      await writeFile(join(tempDir, ".worktreeinclude"), "my-own-pattern/**\n", "utf-8");
+
+      const { updateCommand } = await import("../../cli/commands/update.js");
+      await updateCommand({});
+
+      const wt = await readFile(join(tempDir, ".worktreeinclude"), "utf-8");
+      // Pre-fix: no markers ever appeared (action "skipped" on every run).
+      expect(wt).toContain("HATCH3R:BEGIN");
+      expect(wt).toContain("my-own-pattern/**");
+    });
   });
 
   // D15-SA15.4-03 (Cycle 12 Wave 4, D15, P6): a `--pin-version` typo must be
@@ -1010,6 +1034,55 @@ describe("update command", () => {
       } finally {
         spy.mockRestore();
       }
+    });
+  });
+
+  // Silent-writes sweep (release/2.7.1): `.breaker-state.jsonl` is not a
+  // hatch3r-managed filename, so once the file existed the un-forced
+  // safeWriteFile silently skipped every later persist — update's D8-M4
+  // "recognise an already-open circuit on the next invocation" contract was
+  // dead after the first run. The persist now passes
+  // `{ force: true, backup: false }`.
+  describe("breaker-state persists across a second failing update (silent-writes sweep)", () => {
+    it("the state file reflects run 2's accumulated counts, not run 1's", async () => {
+      await createTestProject(tempDir, { tools: ["cursor"] });
+
+      const adapterTimeoutMod = await import("../../pipeline/adapterTimeout.js");
+      const spy = vi.spyOn(adapterTimeoutMod, "generateWithTimeout").mockResolvedValue({
+        tool: "cursor",
+        completed: false,
+        elapsedMs: 10,
+        error: 'Adapter "cursor" timed out after 180s and was skipped.',
+        warnings: [],
+      });
+
+      const { updateCommand } = await import("../../cli/commands/update.js");
+      const { hydrateBreakersFromLog, BREAKER_STATE_FILE } = await import(
+        "../../pipeline/circuitBreaker.js"
+      );
+      const breakerPath = join(tempDir, HATCH3R_DIR, BREAKER_STATE_FILE);
+      const readTotal = async (): Promise<number> => {
+        const breakers = hydrateBreakersFromLog(await readFile(breakerPath, "utf-8"));
+        return breakers.get("adapter:cursor")?.totalFailures ?? 0;
+      };
+
+      // Run 1 creates `.breaker-state.jsonl`; run 2 hydrates it, records the
+      // run's failures on top, and must OVERWRITE the existing file.
+      // The assertion is per-run-count agnostic (update currently records a
+      // failing adapter more than once per run — the D8-SA8.4-02 single-count
+      // fix landed in sync only): what this test pins is PERSISTENCE, i.e.
+      // run 2 doubles run 1's persisted total instead of leaving the file at
+      // run 1's state (the pre-fix silent skip).
+      await expect(updateCommand({})).rejects.toBeInstanceOf(HatchError);
+      const afterRun1 = await readTotal();
+      expect(afterRun1).toBeGreaterThanOrEqual(1);
+
+      await expect(updateCommand({})).rejects.toBeInstanceOf(HatchError);
+      spy.mockRestore();
+
+      const afterRun2 = await readTotal();
+      // Pre-fix the second persist was skipped: afterRun2 === afterRun1.
+      expect(afterRun2).toBe(afterRun1 * 2);
     });
   });
 

--- a/src/__tests__/merge/predictMergeAction.test.ts
+++ b/src/__tests__/merge/predictMergeAction.test.ts
@@ -206,6 +206,20 @@ describe("predictMergeAction", () => {
     it("predicts 'skipped' for a non-managed filename without force", () => {
       expect(predictMergeAction("user content", "new", "custom.md")).toBe("skipped");
     });
+
+    // Silent-writes sweep (release/2.7.1): the live unmanaged skip branch
+    // gained the G3 unchanged guard, so byte-identical content on a
+    // non-managed filename previews as "unchanged", not "skipped" — keeping
+    // dry-run rows in lockstep with the live write.
+    it("predicts 'unchanged' for a non-managed filename without force when bytes match", () => {
+      expect(predictMergeAction("same bytes", "same bytes", "custom.md")).toBe("unchanged");
+    });
+
+    it("keeps predicting 'skipped' for matching bytes when skipIfUnchanged is false", () => {
+      expect(
+        predictMergeAction("same bytes", "same bytes", "custom.md", { skipIfUnchanged: false }),
+      ).toBe("skipped");
+    });
   });
 });
 

--- a/src/__tests__/merge/safeWrite.errorPaths.test.ts
+++ b/src/__tests__/merge/safeWrite.errorPaths.test.ts
@@ -730,7 +730,7 @@ describe("safeWriteFile additional branches", () => {
       expect(result.warning).toContain("restore the markers");
     });
 
-    it("skip warning for non-managed file without managedContent also includes guidance", async () => {
+    it("skip warning for non-managed file without managedContent names the real condition and recovery paths", async () => {
       const { safeWriteFile } = await import("../../merge/safeWrite.js");
 
       const dir = await createTempDir();
@@ -740,8 +740,16 @@ describe("safeWriteFile additional branches", () => {
       const result = await safeWriteFile(filePath, "new content");
 
       expect(result.action).toBe("skipped");
-      expect(result.warning).toContain("managed block markers");
-      expect(result.warning).toContain("HATCH3R:BEGIN/END");
+      // Silent-writes sweep (release/2.7.1): this branch has no
+      // managedContent, so marker-restoration guidance would be wrong here —
+      // hatch3r's own marker-less JSON outputs land on this branch by design.
+      // The warning names the real condition (existing unmanaged file,
+      // differing bytes) and both recovery paths (`hatch3r sync --force`
+      // with a .bak backup, or delete + re-run).
+      expect(result.warning).toContain("already exists with different content");
+      expect(result.warning).toContain("not hatch3r-managed");
+      expect(result.warning).toContain("hatch3r sync --force");
+      expect(result.warning).toContain(".bak");
     });
   });
 });

--- a/src/__tests__/merge/safeWrite.test.ts
+++ b/src/__tests__/merge/safeWrite.test.ts
@@ -1766,7 +1766,12 @@ describe("no-marker skip warning names a recovering command (D10-SA10.4-01)", ()
     expect(result.warning).not.toContain("re-run hatch3r update");
   });
 
-  it("non-managed filename skip carries the same recovery guidance", async () => {
+  // Silent-writes sweep (release/2.7.1): the unmanaged branch has no
+  // managedContent, so marker-restoration guidance would be wrong there —
+  // hatch3r's own marker-less JSON outputs (.claude/settings.json, .mcp.json)
+  // land on that branch by design. The warning must name the real condition
+  // and the two recovery paths (`hatch3r sync --force` or delete + re-run).
+  it("non-managed filename skip names the real condition and actionable recovery, not marker guidance", async () => {
     const dir = await createTempDir();
     const filePath = join(dir, "custom-file.md");
     await writeFile(filePath, "user content", "utf-8");
@@ -1774,8 +1779,73 @@ describe("no-marker skip warning names a recovering command (D10-SA10.4-01)", ()
     const result = await safeWriteFile(filePath, "new content");
 
     expect(result.action).toBe("skipped");
-    expect(result.warning).toContain("hatch3r sync");
+    expect(result.warning).toContain("hatch3r sync --force");
+    expect(result.warning).toContain("delete the file");
+    // No marker guidance on this branch: restoring HATCH3R:BEGIN/END inside
+    // a raw JSON output is impossible (JSON has no comment syntax).
+    expect(result.warning).not.toContain("HATCH3R:BEGIN");
+    expect(result.warning).not.toContain("restore the markers");
     expect(result.warning).not.toContain("re-run hatch3r update");
+  });
+});
+
+// Silent-writes sweep (release/2.7.1): the unmanaged skip branch previously
+// lacked the G3 unchanged guard every sibling branch applies, so a fresh
+// `init` → `sync` round-trip reported "skipped" + a spurious "markers missing"
+// warning for byte-identical raw JSON outputs (.claude/settings.json,
+// .mcp.json, agent-tool-policies.json).
+describe("unmanaged skip branch: G3 unchanged guard (silent-writes sweep)", () => {
+  let tempDir: string;
+
+  afterEach(async () => {
+    if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function createTempDir(): Promise<string> {
+    tempDir = await mkdtemp(join(tmpdir(), "hatch3r-skipunchanged-"));
+    return tempDir;
+  }
+
+  it("returns 'unchanged' with no warning when the existing unmanaged file already matches the incoming bytes", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "settings.json");
+    const body = JSON.stringify({ env: { X: "1" } }, null, 2);
+    await writeFile(filePath, body, "utf-8");
+
+    const result = await safeWriteFile(filePath, body);
+
+    expect(result.action).toBe("unchanged");
+    expect(result.warning).toBeUndefined();
+    expect(await readFile(filePath, "utf-8")).toBe(body);
+  });
+
+  it("still skips (with warning) when the existing unmanaged file differs", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, "settings.json");
+    await writeFile(filePath, "{\"old\": true}", "utf-8");
+
+    const result = await safeWriteFile(filePath, "{\"new\": true}");
+
+    expect(result.action).toBe("skipped");
+    expect(result.warning).toBeDefined();
+    expect(await readFile(filePath, "utf-8")).toBe("{\"old\": true}");
+  });
+
+  // The (ii)-class fix shape for hatch3r-owned machine-local state
+  // (.failure-log.jsonl rotation, .breaker-state.jsonl persistence): force
+  // writes through an existing unmanaged target, and backup: false leaves no
+  // `.bak` litter for regenerable state.
+  it("force + backup:false updates an existing unmanaged state file and leaves no .bak", async () => {
+    const dir = await createTempDir();
+    const filePath = join(dir, ".breaker-state.jsonl");
+    await writeFile(filePath, "{\"run\":1}\n", "utf-8");
+
+    const result = await safeWriteFile(filePath, "{\"run\":2}\n", { force: true, backup: false });
+
+    expect(result.action).toBe("updated");
+    expect(await readFile(filePath, "utf-8")).toBe("{\"run\":2}\n");
+    const bakExists = await access(filePath + ".bak").then(() => true).catch(() => false);
+    expect(bakExists).toBe(false);
   });
 });
 

--- a/src/__tests__/pipeline/failureLog.test.ts
+++ b/src/__tests__/pipeline/failureLog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -189,6 +189,48 @@ describe("failureLog", () => {
       const rotated = rotateLog(content);
       const parsed = parseFailureLog(rotated);
       expect(parsed).toHaveLength(3);
+    });
+  });
+
+  // Silent-writes sweep (release/2.7.1): the rotation branch of
+  // writeFailureLog targets an EXISTING file whose basename
+  // (`.failure-log.jsonl`) is not hatch3r-managed, so the un-forced
+  // safeWriteFile silently skipped the write — the log never rotated, the
+  // new entry was dropped, and `written: true` was still reported. The fix
+  // passes `{ force: true, backup: false }`.
+  describe("rotation write persists to disk (silent-writes sweep)", () => {
+    let dir: string;
+
+    afterEach(async () => {
+      delete process.env[FAILURE_LOG_MAX_BYTES_ENV];
+      if (dir) await rm(dir, { recursive: true, force: true });
+    });
+
+    it("rotates the on-disk log and appends the new entry when over budget", async () => {
+      dir = await mkdtemp(join(tmpdir(), "hatch3r-faillog-rotate-"));
+      // 12 seed entries (~76 bytes/line ≈ 900+ bytes) over a 600-byte budget
+      // force the rotation branch. Floor (MIN_RETAINED_ENTRIES=10) beats the
+      // half-split (6), so rotation keeps seed-2..seed-11.
+      process.env[FAILURE_LOG_MAX_BYTES_ENV] = "600";
+      const seed = Array.from({ length: 12 }, (_, i) =>
+        formatLogEntry(createFailureLogEntry(`seed-${i}`, new Error(`e-${i}`))),
+      ).join("\n") + "\n";
+      const logPath = join(dir, FAILURE_LOG_FILE);
+      await writeFile(logPath, seed, "utf-8");
+
+      const result = await writeFailureLog(dir, "rotation-probe", new Error("newest failure"));
+
+      expect(result.written).toBe(true);
+      const parsed = parseFailureLog(await readFile(logPath, "utf-8"));
+      // Rotated (10 retained) + the new entry: pre-fix the file kept all 12
+      // seeds and the new entry never reached disk.
+      expect(parsed).toHaveLength(MIN_RETAINED_ENTRIES + 1);
+      expect(parsed[0].phase).toBe("seed-2");
+      expect(parsed[parsed.length - 1].phase).toBe("rotation-probe");
+      expect(parsed[parsed.length - 1].error).toBe("newest failure");
+      // No `.bak` litter next to machine-local regenerable state.
+      const bakExists = await readFile(logPath + ".bak", "utf-8").then(() => true).catch(() => false);
+      expect(bakExists).toBe(false);
     });
   });
 

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -1598,9 +1598,16 @@ async function configCommandImpl(
   if (worktreeActive) {
     const wtContent = await generateWorktreeInclude(manifest, rootDir);
     const wtManaged = extractManagedContent(wtContent);
-    await safeWriteFile(join(rootDir, WORKTREE_INCLUDE_FILE), wtContent, {
+    // Silent-writes sweep (release/2.7.1): appendIfNoBlock restores the
+    // managed block when a user stripped the markers (parity with sync.ts's
+    // D11-H-3 worktree write and update.ts's reconciliation write) — without
+    // it this write silently returned "skipped" and the warning was
+    // discarded, so a config run never healed the file.
+    const wtResult = await safeWriteFile(join(rootDir, WORKTREE_INCLUDE_FILE), wtContent, {
       managedContent: wtManaged,
+      appendIfNoBlock: true,
     });
+    if (wtResult.warning) warn(wtResult.warning);
   } else {
     // D10-SA10.5-F6: `.worktreeinclude` is emitted only while worktree isolation
     // is active (a worktree-capable tool selected AND `worktree.enabled`). When a

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -19,7 +19,7 @@ import { filterMcpJsonOnDisk } from "../../manifest/mcpFilter.js";
 import { rehydrateCustomization } from "../../manifest/rehydrate.js";
 import { writeProvenance, type PerAdapterOutputs } from "../../manifest/provenance.js";
 import { migrateAgentsToHatch3r } from "../../migration/agentsToHatch3r.js";
-import { safeWriteFile, sweepOrphanTmpFiles, formatOrphanTmpSweepDiagnostic } from "../../merge/safeWrite.js";
+import { safeWriteFile, atomicWriteFile, sweepOrphanTmpFiles, formatOrphanTmpSweepDiagnostic } from "../../merge/safeWrite.js";
 import { generateWorktreeInclude, extractManagedContent } from "../../worktree/index.js";
 import {
   DEFAULT_FEATURES,
@@ -205,9 +205,12 @@ async function mapWithConcurrency<T, R>(
  * checked against the existing trimmed lines before being added, so a re-run
  * never duplicates. Distinct from `ensureGitignoreEntry` (which manages the
  * fixed `REQUIRED_GITIGNORE_ENTRIES` set): this appends caller-computed,
- * per-run entries. Writes through `safeWriteFile` (temp+rename) for crash
- * safety, matching the rest of init's writes. Best-effort — a write failure
- * routes through `warn()` (Silent Failure Contract — P5) and never aborts init.
+ * per-run entries. Writes through `atomicWriteFile` (temp+rename) for crash
+ * safety, matching `ensureGitignoreEntry`'s #240 convention — the composed
+ * content is append-only over the existing bytes, and `safeWriteFile` would
+ * skip the write once `.gitignore` exists (silent-writes sweep, release/2.7.1).
+ * Best-effort — a write failure routes through `warn()` (Silent Failure
+ * Contract — P5) and never aborts init.
  */
 async function appendLocalGitignoreEntries(rootDir: string, entries: string[]): Promise<void> {
   const gitignorePath = join(rootDir, ".gitignore");
@@ -222,7 +225,14 @@ async function appendLocalGitignoreEntries(rootDir: string, entries: string[]): 
   if (missing.length === 0) return;
   const separator = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
   try {
-    await safeWriteFile(gitignorePath, `${content}${separator}${missing.join("\n")}\n`);
+    // Silent-writes sweep (release/2.7.1): `.gitignore` is not a
+    // hatch3r-managed filename, so safeWriteFile skipped the write whenever
+    // the file already existed — the per-package entries were silently never
+    // registered on any repo with a pre-existing .gitignore. The composed
+    // content preserves every existing byte (append-only), so write it
+    // through the crash-safe atomic writer directly, matching the sibling
+    // `ensureGitignoreEntry` (src/env/mcpEnv.ts, #240 convention).
+    await atomicWriteFile(gitignorePath, `${content}${separator}${missing.join("\n")}\n`);
   } catch (err) {
     warn(`init: could not register per-package .gitignore entries — ${err instanceof Error ? err.message : String(err)}`);
   }

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -857,7 +857,19 @@ export async function syncCommand(
   let breakers = new Map<string, CircuitBreakerState>();
   try {
     const breakerLog = await readFile(breakerStatePath, "utf-8");
-    breakers = hydrateBreakersFromLog(breakerLog);
+    // Silent-writes sweep (release/2.7.1): hydrateBreakersFromLog keys the map
+    // by serviceId (`adapter:<tool>`) while the adapter loop below keys by
+    // bare tool name, so hydrated entries were never found by
+    // `breakers.get(tool)` — every run re-counted failures from zero even
+    // when the persist succeeded. Re-key into the loop's tool vocabulary at
+    // this seam; each state keeps its full serviceId in `config`, so the
+    // serialized file stays serviceId-keyed.
+    breakers = new Map(
+      [...hydrateBreakersFromLog(breakerLog)].map(([serviceId, state]) => [
+        serviceId.replace(/^adapter:/, ""),
+        state,
+      ]),
+    );
     if (breakers.size > 0) {
       verbose(`Hydrated ${breakers.size} circuit breaker(s) from ${BREAKER_STATE_FILE}`);
     }
@@ -1335,7 +1347,11 @@ export async function syncCommand(
   if (breakers.size > 0) {
     try {
       await mkdir(hatch3rDir, { recursive: true });
-      await safeWriteFile(breakerStatePath, serializeBreakerMap(breakers));
+      // Silent-writes sweep (release/2.7.1): `.breaker-state.jsonl` is not a
+      // hatch3r-managed filename, so once the file existed the un-forced write
+      // was silently skipped and breaker state never persisted past the first
+      // run. hatch3r-owned, machine-local, gitignored state: force, no `.bak`.
+      await safeWriteFile(breakerStatePath, serializeBreakerMap(breakers), { force: true, backup: false });
       verbose(`Persisted ${breakers.size} circuit breaker(s) to ${BREAKER_STATE_FILE}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/src/cli/commands/update.ts
+++ b/src/cli/commands/update.ts
@@ -562,7 +562,19 @@ export async function runRegenerate(
   let breakers = new Map<string, CircuitBreakerState>();
   try {
     const breakerLog = await readFile(breakerStatePath, "utf-8");
-    breakers = hydrateBreakersFromLog(breakerLog);
+    // Silent-writes sweep (release/2.7.1): hydrateBreakersFromLog keys the map
+    // by serviceId (`adapter:<tool>`) while the regenerate loop keys by bare
+    // tool name, so hydrated entries were never found by `breakers.get(tool)`
+    // — every run re-counted failures from zero even when the persist
+    // succeeded. Re-key into the loop's tool vocabulary at this seam; each
+    // state keeps its full serviceId in `config`, so the serialized file
+    // stays serviceId-keyed (parity with sync.ts).
+    breakers = new Map(
+      [...hydrateBreakersFromLog(breakerLog)].map(([serviceId, state]) => [
+        serviceId.replace(/^adapter:/, ""),
+        state,
+      ]),
+    );
     if (breakers.size > 0) {
       verbose(`Hydrated ${breakers.size} circuit breaker(s) from ${BREAKER_STATE_FILE}`);
     }
@@ -781,7 +793,11 @@ export async function runRegenerate(
   if (breakers.size > 0) {
     try {
       await mkdir(hatch3rDir, { recursive: true });
-      await safeWriteFile(breakerStatePath, serializeBreakerMap(breakers));
+      // Silent-writes sweep (release/2.7.1): `.breaker-state.jsonl` is not a
+      // hatch3r-managed filename, so once the file existed the un-forced write
+      // was silently skipped and breaker state never persisted past the first
+      // run. hatch3r-owned, machine-local, gitignored state: force, no `.bak`.
+      await safeWriteFile(breakerStatePath, serializeBreakerMap(breakers), { force: true, backup: false });
       verbose(`Persisted ${breakers.size} circuit breaker(s) to ${BREAKER_STATE_FILE}`);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -864,11 +880,18 @@ export async function runRegenerate(
   if (manifest.worktree?.enabled) {
     const wtContent = await generateWorktreeInclude(manifest, rootDir);
     const wtManaged = extractManagedContent(wtContent);
-    await safeWriteFile(
+    // Silent-writes sweep (release/2.7.1): appendIfNoBlock restores the
+    // managed block when a user stripped the markers, matching sync.ts's
+    // D11-H-3 worktree write — without it this write silently returned
+    // "skipped" (and the warning was discarded) so update never healed the
+    // file. Surface the MergeResult warning like sync does (Silent Failure
+    // Contract, CONSTITUTION §2 P5).
+    const wtResult = await safeWriteFile(
       join(rootDir, WORKTREE_INCLUDE_FILE),
       wtContent,
-      { managedContent: wtManaged, force: options.force },
+      { managedContent: wtManaged, appendIfNoBlock: true, force: options.force },
     );
+    if (wtResult.warning) warn(wtResult.warning);
   }
 
   if (manifest.features.mcp && manifest.mcp.servers.length > 0) {
@@ -1278,7 +1301,14 @@ const MIGRATION_CHECKPOINTS: MigrationCheckpoint[] = [
         };
       }
       const wtContent = await generateWorktreeInclude(updated, rootDir);
+      // Silent-writes sweep (release/2.7.1): `appendIfNoBlock` only takes
+      // effect on the managedContent branch — without `managedContent` this
+      // write silently returned "skipped" whenever a `.worktreeinclude`
+      // already existed (the option was dead). Pass the managed body so an
+      // existing user file gets the block spliced in, matching init.ts's
+      // worktree write.
       await safeWriteFile(join(rootDir, WORKTREE_INCLUDE_FILE), wtContent, {
+        managedContent: extractManagedContent(wtContent),
         appendIfNoBlock: true,
       });
       return { manifest: updated, notices: ["Worktree isolation enabled — .worktreeinclude generated"] };

--- a/src/merge/safeWrite.ts
+++ b/src/merge/safeWrite.ts
@@ -1170,7 +1170,8 @@ export function hasStaleDuplicateGeneratedBody(content: string, filePath: string
  * - Without `managedContent`:
  *   - hatch3r-managed filename OR `force` → `unchanged` when bytes match, else
  *     `updated`.
- *   - otherwise → `skipped`.
+ *   - otherwise → `unchanged` when bytes match (silent-writes sweep: mirrors
+ *     the live skip branch's G3 guard), else `skipped`.
  *
  * The deny-pattern scan is intentionally NOT run here: a deny hit aborts the
  * live write (throws) rather than producing an action, and this predictor
@@ -1255,6 +1256,8 @@ export function predictMergeAction(
     if (skipIfUnchanged && content === existingContent) return "unchanged";
     return "updated";
   }
+  // Silent-writes sweep: mirror the live skip branch's G3 unchanged guard.
+  if (skipIfUnchanged && content === existingContent) return "unchanged";
   return "skipped";
 }
 
@@ -1945,11 +1948,24 @@ async function safeWriteFileLocked(
     return { path: filePath, action: "updated" };
   }
 
-  // #144 (D19-15): Improved recovery guidance — avoid suggesting init --force
+  // Silent-writes sweep (release/2.7.1): identical bytes are "unchanged", not
+  // "skipped" — the same G3 guard every sibling branch applies. Raw JSON
+  // outputs (.claude/settings.json, .mcp.json, agent-tool-policies.json) are
+  // emitted without managed blocks by design (JSON has no comment syntax —
+  // see getMarkersForPath), so a fresh `init` → `sync` round-trip landed here
+  // with byte-identical content and warned "markers missing" on every run.
+  if (skipIfUnchanged && content === existingContent) {
+    return { path: filePath, action: "unchanged" };
+  }
+  // #144 (D19-15) + silent-writes sweep: this branch has no managedContent,
+  // so the marker-restoration guidance the managedContent branch gives would
+  // be wrong here — hatch3r's own marker-less JSON outputs land on this
+  // branch by design. Name the real condition (existing unmanaged file,
+  // differing bytes) and the two recovery paths.
   return {
     path: filePath,
     action: "skipped",
-    warning: `Skipped ${filePath}: managed block markers (HATCH3R:BEGIN/END) missing. To fix: restore the markers around hatch3r content, or run \`hatch3r sync\` to re-splice the managed block while preserving your content below it, or move your custom content elsewhere and re-run the command.`,
+    warning: `Skipped ${filePath}: it already exists with different content and its filename is not hatch3r-managed, so it was left untouched (hatch3r's generated content changed since this file was written, or the file was edited locally). To regenerate it from hatch3r output, run \`hatch3r sync --force\` (the existing file is backed up to a .bak copy first), or delete the file and re-run the command.`,
   };
 }
 

--- a/src/pipeline/failureLog.ts
+++ b/src/pipeline/failureLog.ts
@@ -246,7 +246,13 @@ export async function writeFailureLog(
       const existing = await readFile(logPath, "utf-8");
       if (shouldRotateLog(existing + line)) {
         const rotated = rotateLog(existing);
-        await safeWriteFile(logPath, rotated + line);
+        // Silent-writes sweep (release/2.7.1): the log always EXISTS on this
+        // branch (we just read it) and `.failure-log.jsonl` is not a
+        // hatch3r-managed filename, so without `force` safeWriteFile skipped
+        // the write — rotation never happened and the new entry was silently
+        // dropped while `written: true` was reported. hatch3r-owned,
+        // machine-local, gitignored state: force-overwrite with no `.bak`.
+        await safeWriteFile(logPath, rotated + line, { force: true, backup: false });
         return { written: true };
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

Follow-up to #133 (ledgered there). `safeWriteFile` on an existing target that is neither hatch3r-named nor written with `force` skips non-destructively — four callers that own their target relied on it anyway and silently stopped writing once the file existed. Full call-site sweep with three-way classification (intended-skip / broken-write / already-correct):

- **Failure-log rotation** (`.hatch3r/.failure-log.jsonl`) never rotated and dropped the new entry while reporting `written: true` — now `{ force: true, backup: false }` (hatch3r-owned, gitignored, regenerable state; the 2.7.1 option shape).
- **Circuit-breaker state** (`.hatch3r/.breaker-state.jsonl`) never persisted past the first `sync`/`update`; bonus root cause: hydration keys the map by serviceId (`adapter:<tool>`) while the adapter loops read bare tool names, so even hydrated state was never consulted — persist takes the same force shape and hydration re-keys into the loop vocabulary.
- **`init` per-package `.gitignore` registration** silently skipped every repo with a pre-existing `.gitignore` — the composed content is append-only over existing bytes, so it writes through the crash-safe atomic writer, matching `ensureGitignoreEntry`.
- **Worktree-include writes** in `update` (reconciliation + migration checkpoint) and `config` missed `appendIfNoBlock`/`managedContent`, so a `.worktreeinclude` with stripped markers was skipped forever — all three re-splice the managed block, matching sync's D11-H-3 write.

Also fixes the spurious **"managed block markers missing" warning on every re-sync of raw JSON outputs** (`.claude/settings.json`, `agent-tool-policies.json`, `.mcp.json` — emitted marker-less by design): the unmanaged skip branch now applies the same skip-if-unchanged guard as its siblings (identical bytes report `unchanged`; `predictMergeAction` mirrors it for `--dry-run`), and the residual genuine-difference warning names the real condition and recovery instead of impossible marker restoration. Overwrite-on-sync stays off for those files — they carry user edits.

## Verification

- 8 suites / 671 tests green (rotation rotates; breaker state round-trips with re-keyed hydration; per-package gitignore lands on pre-existing files; worktree-include heals stripped markers; init→sync round-trip emits no skip warning; dry-run parity)
- `tsc --noEmit` 0 errors · lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core merge/write paths and sync/update/init/config behavior for gitignored operational files and user-editable JSON; fixes are targeted but affect every command that persists breaker state or writes unmanaged targets.
> 
> **Overview**
> Fixes a class of bugs where **`safeWriteFile`** treated existing non–hatch3r-managed files as no-op skips: callers that own those paths stopped updating disk after the first write, often while still reporting success.
> 
> **Machine-local / operational writes** now use **`{ force: true, backup: false }`** where appropriate: failure-log **rotation**, circuit-breaker **`.breaker-state.jsonl`** persistence on **`sync`** / **`update`**, and related paths. **`sync`** / **`update`** also **re-key** hydrated breaker maps from `adapter:<tool>` to bare tool names so in-memory state matches the adapter loops.
> 
> **`init --per-package`** registers per-package **`.gitignore`** entries via **`atomicWriteFile`** (append-only) instead of **`safeWriteFile`**, so repos that already had a **`.gitignore`** still get new ignore lines.
> 
> **`.worktreeinclude`** in **`config`**, **`update`** reconciliation, and the worktree migration checkpoint pass **`managedContent`** + **`appendIfNoBlock`** (and surface warnings), aligning with **`sync`** when markers were stripped.
> 
> In **`safeWriteFile`** / **`predictMergeAction`**, the unmanaged skip branch treats **byte-identical** content as **`unchanged`** (no spurious “markers missing” on marker-less JSON like Claude settings). When content really differs, skip warnings describe the actual condition and recovery (**`hatch3r sync --force`** or delete + re-run), not impossible marker restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9fc832bd8e5861d46c89a84180afef4185e13be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->