### PR TITLE
docs: launch-readiness v2.8.6 release-cut refresh (P6 re-verified same-day)

### DIFF
--- a/docs/launch-readiness.md
+++ b/docs/launch-readiness.md
@@ -20,7 +20,7 @@ This document is the single decision point. If a prerequisite is not GREEN, the 
 | Field | Value |
 |-------|-------|
 | Current readiness | NO-GO (v2.6.0 release-cut refresh, 2026-07-14) — see §3 status snapshot. The launch this gate governs is the T2 promotion wave (Show HN, r/ClaudeAI); the PRD §1 HOLD was dispositioned cleared-with-exception (2026-07-12, C12-CL1-1): the named-blocker Critical cluster is registry-done, so T2 now waits only on the three human acts — T0 storefront-count repair, T1 directory submissions, and a GO row in §6/the decision log. |
-| Last reviewed | 2026-07-28 (v2.8.5 release cut — P6 re-verified against the v2.8.0 published evidence in §3, superseding the v2.8.0 refresh landed via #137; v2.8.5's own provenance/SBOM evidence lands post-publish per the release-prep Step 10 checks) |
+| Last reviewed | 2026-08-03 (v2.8.6 release cut — P6 re-verified same-day against v2.8.6's own published evidence in §3: SLSA-v1 provenance attestation, 101 verified registry signatures + 7 attestations with 0 invalid on a scratch install, `sbom.cdx.json` release asset, docs deploy success on merge commit a4e1e05a) |
 | Next review trigger | Any §2 prerequisite flips, or any of the three remaining human acts (T0 storefront repair, T1 submissions, GO decision row) lands |
 
 ## 2. Prerequisites
@@ -36,7 +36,7 @@ All six must read GREEN before any external-facing launch posts. Each row cites 
 | P5 | Marketplace submission package current (`docs/marketplace-submission.md`) | `docs/marketplace-submission.md` (referenced from F18.3.4) | Status field reads `READY` not `PARTIAL`; counts match `governance/inventory.json`; in-app form URLs reachable |
 | P6 | Latest release published with npm provenance + SBOM | Supply-chain floor policy (npm provenance + SBOM + SHA-pinned actions) | `npm view hatch3r@latest dist.signatures` returns provenance attestation; SBOM artifact present on the corresponding GitHub release |
 
-## 3. Status snapshot (v2.8.5 release-cut refresh, 2026-07-28)
+## 3. Status snapshot (v2.8.6 release-cut refresh, 2026-08-03)
 
 | Prereq | Status | Blocker / evidence |
 |--------|--------|--------------------|
@@ -45,7 +45,7 @@ All six must read GREEN before any external-facing launch posts. Each row cites 
 | P3 | GREEN | PRD §5.x is standards-watch only; PRD §14 records the AAIF-stance gate satisfied |
 | P4 | GREEN | PRD §14 documents npm/CLI + Cursor + Claude Code marketplace lanes as live channels; §14 records the 3-lane-documented gate satisfied. Prior sub-note resolved: `add <pack>` shipped as a trust-gated v1 installer in 2.5.0 (Cycle-12 CL-2, D5-SA5.3-09) |
 | P5 | AMBER | `docs/marketplace-submission.md` Status = PARTIAL (agent portion done); human in-app form submissions pending (PRD §1 "submissions pending") |
-| P6 | GREEN | v2.8.0 (published 2026-07-21) verified same-day: `npm view hatch3r@2.8.0 dist.attestations` returns SLSA-v1 provenance (`https://slsa.dev/provenance/v1`); `npm audit signatures` on a scratch install reports 101 verified registry signatures + 7 verified attestations, 0 invalid; `gh release view v2.8.0` ships the `sbom.cdx.json` SBOM asset with the CHANGELOG 2.8.0 section as body; docs deploy workflow concluded success on merge commit 9df32217. Re-verified 2026-07-28 at the v2.8.5 cut (`dist.attestations.provenance.predicateType` + SBOM asset re-checked); v2.8.5's own evidence is re-verified post-publish (release-prep Step 10 item 34). Prior v2.7.2/v2.7.1 evidence retained in the §6 log |
+| P6 | GREEN | v2.8.6 (published 2026-08-03) verified same-day post-publish per release-prep Step 10 item 34: `npm view hatch3r@2.8.6 dist.attestations` returns SLSA-v1 provenance (`https://slsa.dev/provenance/v1`); `npm audit signatures` on a scratch install reports 101 verified registry signatures + 7 verified attestations, 0 invalid; `gh release view v2.8.6` ships the `sbom.cdx.json` SBOM asset with the CHANGELOG 2.8.6 section as body; docs deploy workflow concluded success on merge commit a4e1e05a. Prior v2.8.0/v2.8.5 evidence (same verification set, merge commit 9df32217) and v2.7.2/v2.7.1 evidence retained in the §6 log |
 
 Overall: **NO-GO** for the T2 promotion wave — P2 RED (no GO decision row) + P5 AMBER (submissions pending); P1 has been GREEN since the v2.5.0 refresh, so the gate waits on human acts only, not engineering. No launch decision was taken at the v2.6.0 cut (no §6 row added).
 


### PR DESCRIPTION
Release-prep Step 11 for v2.8.6 (same pattern as #137): §1 Last-reviewed + §3 status snapshot refreshed to the v2.8.6 post-publish evidence gathered at Step 10 item 34 —

- `npm view hatch3r@2.8.6 dist.attestations` → SLSA-v1 provenance (`https://slsa.dev/provenance/v1`)
- `npm audit signatures` on a scratch `npm install hatch3r@2.8.6`: 101 verified registry signatures + 7 verified attestations, 0 invalid
- `gh release view v2.8.6` ships `sbom.cdx.json` with the CHANGELOG 2.8.6 section as body
- deploy-docs concluded success on merge commit a4e1e05a

P6 stays GREEN, now anchored to v2.8.6's own same-day evidence. No launch decision this cycle — no §6 row. Overall gate unchanged (NO-GO on P2 RED + P5 AMBER, human acts only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)